### PR TITLE
entitlement.actions.(hosts/ports) from List to Set

### DIFF
--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -109,13 +109,13 @@ func resourceAppgateEntitlement() *schema.Resource {
 						},
 
 						"hosts": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
 						"ports": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},


### PR DESCRIPTION
both fields have unique element restrictions enforced by the API