### PR TITLE
Entitlement.actions from TypeList to TypeSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.5.0
+VERSION=0.5.1
 
 
 build:

--- a/appgate/hashcode/hashcode.go
+++ b/appgate/hashcode/hashcode.go
@@ -1,0 +1,20 @@
+package hashcode
+
+import "hash/crc32"
+
+// String hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func String(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
+}

--- a/appgate/hashcode/hashcode_test.go
+++ b/appgate/hashcode/hashcode_test.go
@@ -1,0 +1,26 @@
+package hashcode
+
+import (
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	v := "hello, world"
+	expected := String(v)
+	for i := 0; i < 100; i++ {
+		actual := String(v)
+		if actual != expected {
+			t.Fatalf("bad: %#v\n\t%#v", actual, expected)
+		}
+	}
+}
+
+func TestString_positiveIndex(t *testing.T) {
+	// "2338615298" hashes to uint32(2147483648) which is math.MinInt32
+	ips := []string{"192.168.1.3", "192.168.1.5", "2338615298"}
+	for _, ip := range ips {
+		if index := String(ip); index < 0 {
+			t.Fatalf("Bad Index %#v for ip %s", index, ip)
+		}
+	}
+}

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -116,6 +116,7 @@ func resourceAppgateEntitlement() *schema.Resource {
 						"hosts": {
 							Type:     schema.TypeSet,
 							Optional: true,
+							Set:      schema.HashString,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
@@ -204,16 +205,7 @@ func resourceAppgateEntitlementActionHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", copy["subtype"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", copy["action"].(string)))
 	if v, ok := copy["hosts"]; ok {
-		vs := v.([]interface{})
-		s := make([]string, len(vs))
-		for i, raw := range vs {
-			s[i] = raw.(string)
-		}
-		sort.Strings(s)
-
-		for _, v := range s {
-			buf.WriteString(fmt.Sprintf("%s-", v))
-		}
+		buf.WriteString(fmt.Sprintf("%v-", v.(*schema.Set).List()))
 	}
 	if v, ok := copy["ports"]; ok {
 		vs := v.([]interface{})
@@ -410,7 +402,7 @@ func flattenEntitlementActions(actions []openapi.EntitlementAllOfActions, d *sch
 		action := make(map[string]interface{})
 		action["subtype"] = act.Subtype
 		action["action"] = act.Action
-		action["hosts"] = convertStringArrToInterface(act.GetHosts())
+		action["hosts"] = schema.NewSet(schema.HashString, convertStringArrToInterface(act.GetHosts()))
 		action["ports"] = convertStringArrToInterface(act.GetPorts())
 		types := act.GetTypes()
 		if types != nil && inArray(act.Subtype, icmpTypes()) {
@@ -562,8 +554,8 @@ func readEntitlmentActionsFromConfig(actions []interface{}, diags diag.Diagnosti
 		if v, ok := raw["action"]; ok {
 			a.SetAction(v.(string))
 		}
-		if v := raw["hosts"]; len(v.([]interface{})) > 0 {
-			hosts, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if v, ok := raw["hosts"]; ok {
+			hosts, err := readArrayOfStringsFromConfig(v.(*schema.Set).List())
 			if err != nil {
 				return result, diags, fmt.Errorf("Failed to resolve entitlement action hosts: %+v", err)
 			}

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -1,12 +1,15 @@
 package appgate
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v14/openapi"
+	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 
 	"github.com/google/uuid"
 
@@ -93,8 +96,10 @@ func resourceAppgateEntitlement() *schema.Resource {
 			},
 
 			"actions": {
-				Type:     schema.TypeList,
-				Required: true,
+				Type:             schema.TypeSet,
+				Required:         true,
+				Set:              resourceAppgateEntitlementActionHash,
+				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 
@@ -127,29 +132,24 @@ func resourceAppgateEntitlement() *schema.Resource {
 						},
 
 						"monitor": {
-							Type:     schema.TypeList,
-							MaxItems: 1,
-							Optional: true,
-							DefaultFunc: func() (interface{}, error) {
-								var out = make([]map[string]interface{}, 0, 0)
-								m := make(map[string]interface{})
-								m["enabled"] = false
-								m["timeout"] = 30
-								out = append(out, m)
-								return out, nil
-							},
+							Type:             schema.TypeList,
+							MaxItems:         1,
+							Optional:         true,
+							Computed:         true,
 							DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"enabled": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										Default:  false,
+										Type:             schema.TypeBool,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 									},
 									"timeout": {
-										Type:     schema.TypeInt,
-										Optional: true,
-										Default:  30,
+										Type:             schema.TypeInt,
+										Optional:         true,
+										Computed:         true,
+										DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 									},
 								},
 							},
@@ -192,6 +192,90 @@ func resourceAppgateEntitlement() *schema.Resource {
 	}
 }
 
+func resourceAppgateEntitlementActionHash(v interface{}) int {
+	raw := v.(map[string]interface{})
+	// modifying raw actually modifies the values passed to the provider.
+	// Use a copy to avoid that.
+	copy := make((map[string]interface{}))
+	for key, value := range raw {
+		copy[key] = value
+	}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s-", copy["subtype"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", copy["action"].(string)))
+	if v, ok := copy["hosts"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := copy["ports"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+	if v, ok := copy["types"]; ok {
+		vs := v.([]interface{})
+		s := make([]string, len(vs))
+		for i, raw := range vs {
+			s[i] = raw.(string)
+		}
+		sort.Strings(s)
+
+		for _, v := range s {
+			buf.WriteString(fmt.Sprintf("%s-", v))
+		}
+	}
+
+	// monitor is only valid if subtype is tcp_up
+	if copy["subtype"].(string) == "tcp_up" {
+		if v, ok := copy["monitor"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			mHash := resourceAppgateEntitlementActionMonitorHash(v[0])
+			buf.WriteString(fmt.Sprintf("%d-", mHash))
+		} else {
+			// hack, write default values here to correct the hash value.
+			v := map[string]interface{}{
+				"enabled": false,
+				"timeout": 30,
+			}
+			mHash := resourceAppgateEntitlementActionMonitorHash(v)
+			buf.WriteString(fmt.Sprintf("%d-", mHash))
+		}
+	}
+	return hashcode.String(buf.String())
+}
+
+func resourceAppgateEntitlementActionMonitorHash(v interface{}) int {
+	var buf bytes.Buffer
+	m, ok := v.(map[string]interface{})
+
+	if !ok {
+		return 0
+	}
+
+	if v, ok := m["enabled"]; ok {
+		buf.WriteString(fmt.Sprintf("%t-", v.(bool)))
+	}
+	if v, ok := m["timeout"]; ok {
+		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
 func resourceAppgateEntitlementRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
@@ -212,8 +296,8 @@ func resourceAppgateEntitlementRuleCreate(ctx context.Context, d *schema.Resourc
 		args.SetConditionLogic(v.(string))
 	}
 
-	if c, ok := d.GetOk("conditions"); ok {
-		conditions, err := readArrayOfStringsFromConfig(c.(*schema.Set).List())
+	if v, ok := d.GetOk("conditions"); ok {
+		conditions, err := readArrayOfStringsFromConfig(v.(*schema.Set).List())
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -221,7 +305,7 @@ func resourceAppgateEntitlementRuleCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	if v, ok := d.GetOk("actions"); ok {
-		actions, err := readConditionActionsFromConfig(v.([]interface{}))
+		actions, _, err := readEntitlmentActionsFromConfig(v.(*schema.Set).List(), diags)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -288,11 +372,12 @@ func resourceAppgateEntitlementRuleRead(ctx context.Context, d *schema.ResourceD
 			return diag.FromErr(err)
 		}
 	}
-	if entitlement.Actions != nil {
-		if err = d.Set("actions", flattenEntitlementActions(entitlement.Actions)); err != nil {
-			return diag.FromErr(err)
-		}
+
+	actions := flattenEntitlementActions(entitlement.Actions, d)
+	if err = d.Set("actions", actions); err != nil {
+		return diag.FromErr(err)
 	}
+
 	if v, ok := entitlement.GetAppShortcutScriptsOk(); ok {
 		d.Set("app_shortcut_scripts", *v)
 	}
@@ -315,28 +400,49 @@ func flattenEntitlementAppShortcut(in []openapi.AppShortcut) []map[string]interf
 	return out
 }
 
-func flattenEntitlementActions(in []openapi.EntitlementAllOfActions) []map[string]interface{} {
-	var out = make([]map[string]interface{}, len(in), len(in))
-	for i, v := range in {
-		m := make(map[string]interface{})
-		m["subtype"] = v.Subtype
-		m["action"] = v.Action
-		m["hosts"] = v.Hosts
-		m["ports"] = v.Ports
-		m["types"] = v.Types
-		if v.Monitor != nil {
-			m["monitor"] = flattenEntitlementActionMonitor(v.Monitor)
-		}
-		out[i] = m
-	}
-	return out
+func icmpTypes() []string {
+	return []string{"icmp_up", "icmp_down", "icmpv6_up", "icmpv6_down"}
 }
 
-func flattenEntitlementActionMonitor(in *openapi.EntitlementAllOfMonitor) []interface{} {
-	log.Printf("[DEBUG] flattenEntitlementActionMonitor %+v", in)
+func flattenEntitlementActions(actions []openapi.EntitlementAllOfActions, d *schema.ResourceData) *schema.Set {
+	out := []interface{}{}
+	for _, act := range actions {
+		action := make(map[string]interface{})
+		action["subtype"] = act.Subtype
+		action["action"] = act.Action
+		action["hosts"] = convertStringArrToInterface(act.GetHosts())
+		action["ports"] = convertStringArrToInterface(act.GetPorts())
+		types := act.GetTypes()
+		if types != nil && inArray(act.Subtype, icmpTypes()) {
+			action["types"] = convertStringArrToInterface(act.GetTypes())
+		}
+		if act.Monitor != nil && act.Subtype == "tcp_up" {
+			action["monitor"] = flattenEntitlementActionMonitor(act.GetMonitor())
+			dataActions := d.Get("actions")
+			hash := resourceAppgateEntitlementActionHash(action)
+
+			for _, k := range dataActions.(*schema.Set).List() {
+				log.Printf("[DEBUG] flattenEntitlementActions action list OLD %+v", k)
+				oldHash := resourceAppgateEntitlementActionHash(k)
+				if oldHash == hash {
+					oldV := k.(map[string]interface{})
+					if v, ok := oldV["monitor"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+						log.Printf("[DEBUG] flattenEntitlementActions OLD MONITOR %+v", v)
+						action["monitor"] = v
+					}
+				}
+			}
+		}
+		out = append(out, action)
+	}
+	return schema.NewSet(resourceAppgateEntitlementActionHash, out)
+}
+
+func flattenEntitlementActionMonitor(monitor openapi.EntitlementAllOfMonitor) []interface{} {
+	log.Printf("[DEBUG] flattenEntitlementActionMonitor %+v", monitor)
 	m := make(map[string]interface{})
-	m["enabled"] = in.Enabled
-	m["timeout"] = in.Timeout
+	m["enabled"] = *monitor.Enabled
+	m["timeout"] = int(*monitor.Timeout)
 
 	return []interface{}{m}
 }
@@ -344,6 +450,7 @@ func flattenEntitlementActionMonitor(in *openapi.EntitlementAllOfMonitor) []inte
 func resourceAppgateEntitlementRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Updating Entitlement: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Updating Entitlement id: %+v", d.Id())
+	var diags diag.Diagnostics
 	token := meta.(*Client).Token
 	api := meta.(*Client).API.EntitlementsApi
 
@@ -388,7 +495,7 @@ func resourceAppgateEntitlementRuleUpdate(ctx context.Context, d *schema.Resourc
 
 	if d.HasChange("actions") {
 		_, v := d.GetChange("actions")
-		actions, err := readConditionActionsFromConfig(v.([]interface{}))
+		actions, _, err := readEntitlmentActionsFromConfig(v.(*schema.Set).List(), diags)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -441,13 +548,13 @@ func resourceAppgateEntitlementRuleDelete(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func readConditionActionsFromConfig(actions []interface{}) ([]openapi.EntitlementAllOfActions, error) {
+func readEntitlmentActionsFromConfig(actions []interface{}, diags diag.Diagnostics) ([]openapi.EntitlementAllOfActions, diag.Diagnostics, error) {
 	result := make([]openapi.EntitlementAllOfActions, 0)
 	for _, action := range actions {
 		if action == nil {
 			continue
 		}
-		a := openapi.NewEntitlementAllOfActionsWithDefaults()
+		a := openapi.EntitlementAllOfActions{}
 		raw := action.(map[string]interface{})
 		if v, ok := raw["subtype"]; ok {
 			a.SetSubtype(v.(string))
@@ -458,27 +565,35 @@ func readConditionActionsFromConfig(actions []interface{}) ([]openapi.Entitlemen
 		if v := raw["hosts"]; len(v.([]interface{})) > 0 {
 			hosts, err := readArrayOfStringsFromConfig(v.([]interface{}))
 			if err != nil {
-				return result, fmt.Errorf("Failed to resolve condition action hosts: %+v", err)
+				return result, diags, fmt.Errorf("Failed to resolve entitlement action hosts: %+v", err)
 			}
 			a.SetHosts(hosts)
 		}
 		if v := raw["ports"]; len(v.([]interface{})) > 0 {
 			ports, err := readArrayOfStringsFromConfig(v.([]interface{}))
 			if err != nil {
-				return result, fmt.Errorf("Failed to resolve condition action ports: %+v", err)
+				return result, diags, fmt.Errorf("Failed to resolve entitlement action ports: %+v", err)
 			}
 			a.SetPorts(ports)
 		}
 		if v := raw["types"]; len(v.([]interface{})) > 0 {
+			if !inArray(a.GetSubtype(), icmpTypes()) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Invalid usage of types.",
+					Detail:   "ICMP type. Only valid for icmp subtypes.",
+				})
+			}
 			types, err := readArrayOfStringsFromConfig(v.([]interface{}))
 			if err != nil {
-				return result, fmt.Errorf("Failed to resolve condition action types: %+v", err)
+				return result, diags, fmt.Errorf("Failed to resolve entitlment action types: %+v", err)
 			}
 			a.SetTypes(types)
 		}
-		monitor := openapi.NewEntitlementAllOfMonitorWithDefaults()
-		if v, ok := raw["monitor"]; ok {
-			rawMonitors := v.([]interface{})
+
+		if v, ok := raw["monitor"].([]interface{}); ok && len(v) > 0 {
+			monitor := openapi.NewEntitlementAllOfMonitorWithDefaults()
+			rawMonitors := v
 			for _, v := range rawMonitors {
 				rawMonitor := v.(map[string]interface{})
 				if v, ok := rawMonitor["enabled"]; ok {
@@ -488,11 +603,11 @@ func readConditionActionsFromConfig(actions []interface{}) ([]openapi.Entitlemen
 					monitor.SetTimeout(int32(v.(int)))
 				}
 			}
+			a.SetMonitor(*monitor)
 		}
-		a.SetMonitor(*monitor)
-		result = append(result, *a)
+		result = append(result, a)
 	}
-	return result, nil
+	return result, diags, nil
 }
 
 func readAppShortcutFromConfig(shortcuts []interface{}) ([]openapi.AppShortcut, error) {

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -114,13 +114,13 @@ func resourceAppgateEntitlement() *schema.Resource {
 						},
 
 						"hosts": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 
 						"ports": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 						},

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -21,16 +21,17 @@ func TestAccEntitlementBasicPing(t *testing.T) {
 				Config: testAccCheckEntitlementBasicPing(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEntitlementExists(resourceName),
+					testAccCheckExampleWidgetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
 					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "5"),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "10.0.0.1"),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "10.0.0.0/24"),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "hostname.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "10.0.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "10.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "aws://security-group:accounting"),
 					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.3", "dns://hostname.company.com"),
-					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.4", "aws://security-group:accounting"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.4", "hostname.company.com"),
 					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "0"),
 
 					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "icmp_up"),
@@ -327,7 +328,7 @@ func TestAccEntitlementUpdateActionOrder(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
-					resource.TestCheckResourceAttr(resourceName, "site", "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4"),
+					resource.TestCheckResourceAttrPair(resourceName, "site", "data.appgatesdp_site.default_site", "id"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
 					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
@@ -436,6 +437,212 @@ resource "appgatesdp_entitlement" "test_action_order_item" {
 			enabled = true
 			timeout = 22
 		}
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}
+
+func TestAccEntitlementUpdateActionHostOrder(t *testing.T) {
+	resourceName := "appgatesdp_entitlement.test_action_order_hosts"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckEntitlementActionHostSets(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "103.15.3.254/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "172.17.3.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "tcp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.monitor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.subtype", "udp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttrPair(resourceName, "site", "data.appgatesdp_site.default_site", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckEntitlementActionHostSetsUpdatedOrder(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "103.15.3.254/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "172.17.3.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "tcp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.monitor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.subtype", "udp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcut_scripts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "conditions.0", "data.appgatesdp_condition.always", "id"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttrPair(resourceName, "site", "data.appgatesdp_site.default_site", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckEntitlementActionHostSets(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgatesdp_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgatesdp_entitlement" "test_action_order_hosts" {
+	name = "%s"
+	site = data.appgatesdp_site.default_site.id
+	conditions = [
+		data.appgatesdp_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts = [
+			"103.15.3.254/32",
+			"172.17.3.255/32",
+			"192.168.2.255/32",
+		]
+		ports   = ["53"]
+	}
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}
+
+func testAccCheckEntitlementActionHostSetsUpdatedOrder(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgatesdp_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgatesdp_entitlement" "test_action_order_hosts" {
+	name = "%s"
+	site = data.appgatesdp_site.default_site.id
+	conditions = [
+		data.appgatesdp_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts = [
+			"192.168.2.255/32",
+			"103.15.3.254/32",
+			"172.17.3.255/32",
+		]
+		ports   = ["53"]
+	}
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
 	}
 	app_shortcuts {
 		name       = "%s"

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccEntitlementBasicPing(t *testing.T) {
-	resourceName := "appgatesdp_entitlement.test_item"
+	resourceName := "appgatesdp_entitlement.test_ping_item"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -95,7 +95,7 @@ data "appgatesdp_site" "default_site" {
 data "appgatesdp_condition" "always" {
   condition_name = "Always"
 }
-resource "appgatesdp_entitlement" "test_item" {
+resource "appgatesdp_entitlement" "test_ping_item" {
   name        = "%s"
   site = data.appgatesdp_site.default_site.id
     conditions = [
@@ -282,7 +282,7 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
 }
 
 func TestAccEntitlementUpdateActionOrder(t *testing.T) {
-	resourceName := "appgate_entitlement.test_item"
+	resourceName := "appgatesdp_entitlement.test_action_order_item"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -322,12 +322,10 @@ func TestAccEntitlementUpdateActionOrder(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
-					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", "gcwogskflp"),
 					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
 					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "name", "gcwogskflp"),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
 					resource.TestCheckResourceAttr(resourceName, "site", "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4"),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
@@ -359,17 +357,17 @@ func TestAccEntitlementUpdateActionOrder(t *testing.T) {
 
 func testAccCheckEntitlementMultipleActions(rName string) string {
 	return fmt.Sprintf(`
-data "appgate_site" "default_site" {
+data "appgatesdp_site" "default_site" {
 	site_name = "Default Site"
 }
-data "appgate_condition" "always" {
+data "appgatesdp_condition" "always" {
 	condition_name = "Always"
 }
-resource "appgate_entitlement" "test_item" {
+resource "appgatesdp_entitlement" "test_action_order_item" {
 	name = "%s"
-	site = data.appgate_site.default_site.id
+	site = data.appgatesdp_site.default_site.id
 	conditions = [
-		data.appgate_condition.always.id
+		data.appgatesdp_condition.always.id
 	]
 	tags = [
 		"terraform",
@@ -404,17 +402,17 @@ resource "appgate_entitlement" "test_item" {
 
 func testAccCheckEntitlementWithActionOrderUpdated(rName string) string {
 	return fmt.Sprintf(`
-data "appgate_site" "default_site" {
+data "appgatesdp_site" "default_site" {
 	site_name = "Default Site"
 }
-data "appgate_condition" "always" {
+data "appgatesdp_condition" "always" {
 	condition_name = "Always"
 }
-resource "appgate_entitlement" "test_item" {
+resource "appgatesdp_entitlement" "test_action_order_item" {
 	name = "%s"
-	site = data.appgate_site.default_site.id
+	site = data.appgatesdp_site.default_site.id
 	conditions = [
-		data.appgate_condition.always.id
+		data.appgatesdp_condition.always.id
 	]
 	tags = [
 		"terraform",

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -21,7 +21,6 @@ func TestAccEntitlementBasicPing(t *testing.T) {
 				Config: testAccCheckEntitlementBasicPing(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEntitlementExists(resourceName),
-					testAccCheckExampleWidgetExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "actions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
@@ -637,6 +636,216 @@ resource "appgatesdp_entitlement" "test_action_order_hosts" {
 			"172.17.3.255/32",
 		]
 		ports   = ["53"]
+	}
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}
+
+func TestAccEntitlementUpdateActionPortsSetOrder(t *testing.T) {
+	resourceName := "appgatesdp_entitlement.test_action_order_hosts"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckEntitlementActionPortsSets(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "103.15.3.254/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "172.17.3.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.0", "21"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.1", "22"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.2", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "tcp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.monitor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.subtype", "udp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttrPair(resourceName, "site", "data.appgatesdp_site.default_site", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckEntitlementActionPortsSetsUpdatedOrder(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "103.15.3.254/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.1", "172.17.3.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.2", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "30"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.0", "21"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.1", "22"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.2", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "tcp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.monitor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.subtype", "udp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcut_scripts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "conditions.0", "data.appgatesdp_condition.always", "id"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttrPair(resourceName, "site", "data.appgatesdp_site.default_site", "id"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckEntitlementActionPortsSets(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgatesdp_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgatesdp_entitlement" "test_action_order_hosts" {
+	name = "%s"
+	site = data.appgatesdp_site.default_site.id
+	conditions = [
+		data.appgatesdp_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts = [
+			"103.15.3.254/32",
+			"172.17.3.255/32",
+			"192.168.2.255/32",
+		]
+		ports   = ["53", "22", "21"]
+	}
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}
+
+func testAccCheckEntitlementActionPortsSetsUpdatedOrder(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgatesdp_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgatesdp_entitlement" "test_action_order_hosts" {
+	name = "%s"
+	site = data.appgatesdp_site.default_site.id
+	conditions = [
+		data.appgatesdp_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts = [
+			"192.168.2.255/32",
+			"103.15.3.254/32",
+			"172.17.3.255/32",
+		]
+		ports   = ["21", "22", "53"]
 	}
 	actions {
 		action  = "allow"

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -280,3 +280,170 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
   }
 `, rName, rName)
 }
+
+func TestAccEntitlementUpdateActionOrder(t *testing.T) {
+	resourceName := "appgate_entitlement.test_item"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckItemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckEntitlementMultipleActions(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.monitor.0.timeout", "22"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.subtype", "tcp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.0.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.action", "allow"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.hosts.0", "192.168.2.255/32"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.monitor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.ports.0", "53"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.subtype", "udp_up"),
+					resource.TestCheckResourceAttr(resourceName, "actions.1.types.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.color_code", "5"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.name", "gcwogskflp"),
+					resource.TestCheckResourceAttr(resourceName, "app_shortcuts.0.url", "https://www.google.com"),
+					resource.TestCheckResourceAttr(resourceName, "condition_logic", "and"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", "gcwogskflp"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "site", "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckEntitlementWithActionOrderUpdated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEntitlementExists(resourceName),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccEntitlementImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckEntitlementMultipleActions(rName string) string {
+	return fmt.Sprintf(`
+data "appgate_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgate_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgate_entitlement" "test_item" {
+	name = "%s"
+	site = data.appgate_site.default_site.id
+	conditions = [
+		data.appgate_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+		monitor {
+		enabled = true
+		timeout = 22
+		}
+	}
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}
+
+func testAccCheckEntitlementWithActionOrderUpdated(rName string) string {
+	return fmt.Sprintf(`
+data "appgate_site" "default_site" {
+	site_name = "Default Site"
+}
+data "appgate_condition" "always" {
+	condition_name = "Always"
+}
+resource "appgate_entitlement" "test_item" {
+	name = "%s"
+	site = data.appgate_site.default_site.id
+	conditions = [
+		data.appgate_condition.always.id
+	]
+	tags = [
+		"terraform",
+		"api-created"
+	]
+	disabled = true
+	condition_logic = "and"
+	# Updated the order of the actions
+	actions {
+		action  = "allow"
+		subtype = "udp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+	}
+	actions {
+		action  = "allow"
+		subtype = "tcp_up"
+		hosts   = ["192.168.2.255/32"]
+		ports   = ["53"]
+		monitor {
+			enabled = true
+			timeout = 22
+		}
+	}
+	app_shortcuts {
+		name       = "%s"
+		url        = "https://www.google.com"
+		color_code = 5
+	}
+}
+	`, rName, rName)
+}

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -168,3 +168,11 @@ func getResourceFileContent(d *schema.ResourceData) ([]byte, error) {
 func suppressMissingOptionalConfigurationBlock(k, old, new string, d *schema.ResourceData) bool {
 	return old == "1" && new == "0"
 }
+
+func convertStringArrToInterface(strs []string) []interface{} {
+	arr := make([]interface{}, len(strs))
+	for i, str := range strs {
+		arr[i] = str
+	}
+	return arr
+}


### PR DESCRIPTION
Updated Entitlement.actions from TypeList to TypeSet

this solves, #98

acceptance test result
<details>

```
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestGetToken200
--- PASS: TestGetToken200 (0.01s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (15.06s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (7.60s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (4.02s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (4.58s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (4.11s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.47s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.31s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.49s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccAppgateAdministrativeRoleDataSource (20.59s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccRingfenceRuleBasicTCP (25.28s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccApplianceBasicGateway (26.21s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccLocalUserBasic (26.39s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccGlobalSettingsBasic (26.75s)
=== CONT  TestAccClientConnectionsBasic
--- PASS: TestAccIPPoolBasic (27.04s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccTrustedCertificateBasic (27.10s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccMfaProviderBasic (27.15s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccLdapIdentityProviderBasic (27.26s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccPolicyBasic (28.17s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccAdminMfaSettingsBasic (28.34s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccRingfenceRuleBasicICMP (28.45s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccRadiusIdentityProviderBasic (29.40s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (29.55s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccCriteriaScriptBasic (28.99s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicWithMonitor (50.21s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (51.29s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (51.87s)
--- PASS: TestAccEntitlementUpdateActionOrder (51.88s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (24.48s)
--- PASS: TestAccAppgateMfaProviderDataSource (23.50s)
--- PASS: TestAccEntitlementScriptBasic (28.01s)
--- PASS: TestAccBlacklistUserBasic (27.40s)
--- PASS: TestAccEntitlementBasicPing (29.26s)
--- PASS: TestAccDeviceScriptBasic (28.40s)
--- PASS: TestAccClientConnectionsBasic (28.23s)
--- PASS: TestAccConditionBasic (28.31s)
--- PASS: TestAccadministrativeRoleWithScope (28.47s)
--- PASS: TestAccadministrativeRoleBasic (26.27s)
--- PASS: TestAccApplianceConnector (28.62s)
--- PASS: TestAccApplianceCustomizationBasic (27.79s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (10.38s)
--- PASS: TestAccSiteBasic (60.34s)
--- PASS: TestAccSamlIdentityProviderBasic (62.74s)
--- PASS: TestAccApplianceBasicController (38.81s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	117.708s
```


</details> 