### PR TITLE
s/OnBoardedDevice/RegisteredDevice/

### DIFF
--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -123,7 +123,7 @@ func resourceAppgateAdministrativeRole() *schema.Resource {
 									"TokenRecord",
 									"Blacklist",
 									"UserLicense",
-									"OnBoardedDevice",
+									"RegisteredDevice",
 									"AllocatedIp",
 									"SessionInfo",
 									"AuditLog",

--- a/website/docs/r/administrative_role.markdown
+++ b/website/docs/r/administrative_role.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 Administrative privilege list.
 
 * `type`: (Required)  Enum values: `All,View,Create,Edit,Tag,Delete,Revoke,Export,Upgrade,RenewCertificate,DownloadLogs,Test,GetUserAttributes,Backup,CheckStatus,Reevaluate`The type of the Privilege defines the possible administrator actions.
-* `target`: (Required)  Enum values: `All,Appliance,Condition,CriteriaScript,Entitlement,AdministrativeRole,IdentityProvider,MfaProvider,IpPool,LocalUser,Policy,Site,DeviceScript,EntitlementScript,RingfenceRule,ApplianceCustomization,OtpSeed,TokenRecord,Blacklist,UserLicense,OnBoardedDevice,AllocatedIp,SessionInfo,AuditLog,AdminMessage,GlobalSetting,CaCertificate,File,FailedAuthentication`The target of the Privilege defines the possible target objects for that type.
+* `target`: (Required)  Enum values: `All,Appliance,Condition,CriteriaScript,Entitlement,AdministrativeRole,IdentityProvider,MfaProvider,IpPool,LocalUser,Policy,Site,DeviceScript,EntitlementScript,RingfenceRule,ApplianceCustomization,OtpSeed,TokenRecord,Blacklist,UserLicense,RegisteredDevice,AllocatedIp,SessionInfo,AuditLog,AdminMessage,GlobalSetting,CaCertificate,File,FailedAuthentication`The target of the Privilege defines the possible target objects for that type.
 * `scope`:  (Optional) The scope of the Privilege. Only applicable to certain type-target combinations. Some types depends on the IdP/MFA type, such as GetUserAttributes. This field must be omitted if not applicable.
 * `default_tags`:  (Optional) The items in this list would be added automatically to the newly created objects' tags. Only applicable on "Create" type and targets with tagging capability. This field must be omitted if not applicable.
 ### tags


### PR DESCRIPTION
`OnBoardedDevice` was deprecated several versions back and renamed `RegisteredDevice`. this PR fixes #115 
```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.01s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.57s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (4.13s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (4.05s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (4.10s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (6.16s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.40s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.73s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (9.74s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccApplianceConnector
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccClientConnectionsBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccAppgateApplianceCustomizationDataSource
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (22.26s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (22.60s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccAppgateMfaProviderDataSource (22.63s)
=== CONT  TestAccTrustedCertificateBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (23.27s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccApplianceCustomizationBasic (24.99s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccadministrativeRoleBasic (26.32s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccadministrativeRoleWithScope (26.72s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccEntitlementBasicPing (27.14s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccBlacklistUserBasic (27.41s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccConditionBasic (27.55s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccLocalUserBasic (27.99s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccClientConnectionsBasic (28.27s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccDeviceScriptBasic (28.28s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccCriteriaScriptBasic (28.56s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccApplianceBasicGateway (29.14s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccApplianceConnector (29.43s)
--- PASS: TestAccEntitlementScriptBasic (29.92s)
--- PASS: TestAccTrustedCertificateBasic (26.21s)
--- PASS: TestAccEntitlementBasicWithMonitor (49.54s)
--- PASS: TestAccIPPoolBasic (27.30s)
--- PASS: TestAccLdapIdentityProviderBasic (28.77s)
--- PASS: TestAccEntitlementUpdateActionOrder (51.15s)
--- PASS: TestAccRingfenceRuleBasicICMP (24.56s)
--- PASS: TestAccPolicyBasic (24.47s)
--- PASS: TestAccMfaProviderBasic (23.50s)
--- PASS: TestAccRingfenceRuleBasicTCP (26.51s)
--- PASS: TestAccAdminMfaSettingsBasic (25.02s)
--- PASS: TestAccRadiusIdentityProviderBasic (26.52s)
--- PASS: TestAccGlobalSettingsBasic (26.04s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (25.35s)
--- PASS: TestAccApplianceBasicController (59.21s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (30.83s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (32.06s)
--- PASS: TestAccSiteBasic (38.65s)
--- PASS: TestAccSamlIdentityProviderBasic (43.32s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	115.530s
```