### PR TITLE
Site 124

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.5.4
+VERSION=0.5.5
 
 
 build:

--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -51,12 +51,7 @@ func resourceAppgateAdministrativeRole() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"privileges": {
 				Type:     schema.TypeList,

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -76,12 +76,7 @@ func resourceAppgateAppliance() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"hostname": {
 				Type:        schema.TypeString,

--- a/appgate/resource_appgate_appliance_customization.go
+++ b/appgate/resource_appgate_appliance_customization.go
@@ -54,12 +54,7 @@ func resourceAppgateApplianceCustomizations() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"file": {
 				Type:        schema.TypeString,

--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -52,12 +52,7 @@ func resourceAppgateCondition() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"expression": {
 				Type:        schema.TypeString,

--- a/appgate/resource_appgate_criteria_script.go
+++ b/appgate/resource_appgate_criteria_script.go
@@ -50,12 +50,7 @@ func resourceAppgateCriteriaScript() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"expression": {
 				Type:        schema.TypeString,

--- a/appgate/resource_appgate_device_script.go
+++ b/appgate/resource_appgate_device_script.go
@@ -50,12 +50,7 @@ func resourceAppgateDeviceScript() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"filename": {
 				Type:        schema.TypeString,

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -54,12 +54,7 @@ func resourceAppgateEntitlement() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"disabled": {
 				Type:     schema.TypeBool,

--- a/appgate/resource_appgate_entitlement_script.go
+++ b/appgate/resource_appgate_entitlement_script.go
@@ -50,12 +50,7 @@ func resourceAppgateEntitlementScript() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"type": {
 				Type:     schema.TypeString,

--- a/appgate/resource_appgate_ip_pool.go
+++ b/appgate/resource_appgate_ip_pool.go
@@ -50,12 +50,7 @@ func resourceAppgateIPPool() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"ip_version6": {
 				Type:     schema.TypeBool,

--- a/appgate/resource_appgate_mfa_provider.go
+++ b/appgate/resource_appgate_mfa_provider.go
@@ -50,12 +50,7 @@ func resourceAppgateMfaProvider() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"type": {
 				Type:     schema.TypeString,

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -49,12 +49,7 @@ func resourceAppgatePolicy() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"disabled": {
 				Type:     schema.TypeBool,

--- a/appgate/resource_appgate_ringfence_rule.go
+++ b/appgate/resource_appgate_ringfence_rule.go
@@ -50,12 +50,7 @@ func resourceAppgateRingfenceRule() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"actions": {
 				Type:     schema.TypeList,

--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -57,12 +57,7 @@ func resourceAppgateSite() *schema.Resource {
 				Optional:    true,
 			},
 
-			"tags": {
-				Type:        schema.TypeSet,
-				Description: "Array of tags.",
-				Optional:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-			},
+			"tags": tagsSchema(),
 
 			"short_name": {
 				Type:        schema.TypeString,


### PR DESCRIPTION
This solves the issue #124 .

`web_proxy_verify_upstream_certificate` is only present in 5.3, (not present in 5.4.0 either) 

Patches:

In the example hcl from #124 I noticed that tags was automatically converted to lowercase by the controller. so I made a refactor that will convert all tags to lowercase and supress any diffs for case changes.


Acceptance test coverage for `5.3.2-23587-release`
<details>

```bash
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (11.23s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (4.22s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (4.30s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (5.95s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (4.44s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.36s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.67s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.45s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccPolicyBasic
=== CONT  TestAccClientConnectionsBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccAppgateAdministrativeRoleDataSource (20.78s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccEntitlementScriptBasic (22.73s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccAdminMfaSettingsBasic (23.14s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccCriteriaScriptBasic (24.29s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccPolicyBasic (24.37s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccClientConnectionsBasic (24.60s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccBlacklistUserBasic (24.95s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccDeviceScriptBasic (25.00s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccConditionBasic (25.16s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccMfaProviderBasic (25.32s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccRingfenceRuleBasicICMP (25.78s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccTrustedCertificateBasic (25.83s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccApplianceBasicGateway (26.27s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccRadiusIdentityProviderBasic (26.46s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccEntitlementBasicPing (27.29s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (27.60s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccRingfenceRuleBasicTCP (27.65s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (27.88s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (19.88s)
--- PASS: TestAccAppgateMfaProviderDataSource (20.26s)
--- PASS: TestAccEntitlementBasicWithMonitor (45.52s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (20.82s)
--- PASS: TestAccLdapIdentityProviderBasic (26.39s)
--- PASS: TestAccApplianceConnector (25.41s)
--- PASS: TestAccadministrativeRoleWithScope (23.86s)
--- PASS: TestAccApplianceCustomizationBasic (24.43s)
--- PASS: TestAccadministrativeRoleBasic (24.41s)
--- PASS: TestAccLocalUserBasic (24.19s)
--- PASS: TestAccGlobalSettingsBasic (23.13s)
--- PASS: TestAccIPPoolBasic (24.40s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (23.95s)
--- PASS: TestAccSiteBasic (53.95s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (28.57s)
--- PASS: TestAccEntitlementUpdateActionOrder (29.04s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (29.80s)
--- PASS: TestAccApplianceBasicController (38.12s)
--- PASS: TestAccSamlIdentityProviderBasic (38.20s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	109.693s

```
</details>


Acceptance test coverage for `5.2.4-24406-release`
<details>

```bash
> TF_ACC=1 \
go test -v -timeout 120m github.com/appgate/terraform-provider-appgatesdp/appgate -run '^(TestAccSite*.+)$'
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== CONT  TestAccSiteBasic
--- PASS: TestAccSiteBasic (26.05s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	26.077s

```
</details>

