### PR TITLE
site.name_resolvers.aws_resolver withouut secret_access_key

### DIFF
--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -1115,11 +1115,11 @@ func readAWSResolversFromConfig(awsConfigs []interface{}) ([]openapi.SiteAllOfNa
 		if v, ok := raw["use_iam_role"]; ok && v.(bool) {
 			row.SetUseIAMRole(v.(bool))
 		}
-		if v, ok := raw["access_key_id"]; ok {
-			row.SetAccessKeyId(v.(string))
+		if v, ok := raw["access_key_id"].(string); ok && len(v) > 0 {
+			row.SetAccessKeyId(v)
 		}
-		if v, ok := raw["secret_access_key"]; ok {
-			row.SetSecretAccessKey(v.(string))
+		if v, ok := raw["secret_access_key"].(string); ok && len(v) > 0 {
+			row.SetSecretAccessKey(v)
 		}
 		if v, ok := raw["https_proxy"]; ok && len(v.(string)) > 0 {
 			row.SetHttpsProxy(v.(string))
@@ -1136,7 +1136,6 @@ func readAWSResolversFromConfig(awsConfigs []interface{}) ([]openapi.SiteAllOfNa
 				row.SetAssumedRoles(assumedRoles)
 			}
 		}
-
 		result = append(result, row)
 	}
 	return result, nil

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -94,7 +94,7 @@ func TestAccSiteBasic(t *testing.T) {
 			{
 				ResourceName:     resourceName,
 				ImportState:      true,
-				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
 			},
 			{
 				Config: testAccCheckSiteUpdate(),
@@ -414,4 +414,118 @@ func testAccCheckSiteExists(resource string) resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func TestAccSiteBasicAwsResolverWithoutSecret(t *testing.T) {
+	resourceName := "appgatesdp_site.test_site"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name": rName,
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSiteDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteBasicAwsResolverConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v4", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v6", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.excluded_subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_based_routing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_mappings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.%", "11"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.access_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.assumed_roles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.https_proxy", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.name", "AWS Resolver 10"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.regions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.regions.0", "eu-central-1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.regions.1", "eu-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.resolve_with_master_credentials", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.secret_access_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.update_interval", "59"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.use_iam_role", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.vpc_auto_discovery", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.0.vpcs.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.esx_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.gcp_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.use_hosts_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "network_subnets.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "network_subnets.0", "10.0.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "developer"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.ip_access_log_interval_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.snat", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.state_sharing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_key_store", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_verify_upstream_certificate", "true"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccSiteBasicAwsResolverConfig(context map[string]interface{}) string {
+	return Nprintf(`
+    resource "appgatesdp_site" "test_site" {
+        name       = "%{name}"
+        tags = [
+          "developer",
+          "api-created"
+        ]
+        entitlement_based_routing = false
+        network_subnets = [
+          "10.0.0.0/16"
+        ]
+        default_gateway {
+          enabled_v4       = false
+          enabled_v6       = false
+          excluded_subnets = []
+        }
+        name_resolution {
+          aws_resolvers {
+            name = "AWS Resolver 10"
+            regions = [
+              "eu-central-1",
+              "eu-west-1"
+            ]
+            update_interval                 = 59
+            vpcs                            = []
+            vpc_auto_discovery              = true
+            use_iam_role                    = true
+            resolve_with_master_credentials = true
+          }
+        }
+      }
+    `, context)
 }


### PR DESCRIPTION
This partially fixes https://github.com/appgate/terraform-provider-appgatesdp/issues/122


acceptance test result for 5.3.2-23587-release

```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.01s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.79s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (4.00s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (4.05s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (4.16s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (4.45s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.15s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.40s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.57s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccClientConnectionsBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (20.24s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccDeviceScriptBasic (22.46s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccClientConnectionsBasic (23.21s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccBlacklistUserBasic (23.87s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccMfaProviderBasic (24.07s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccGlobalSettingsBasic (24.17s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccConditionBasic (24.35s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccEntitlementScriptBasic (24.79s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccCriteriaScriptBasic (25.07s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccIPPoolBasic (25.42s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccRadiusIdentityProviderBasic (25.53s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccLdapIdentityProviderBasic (25.55s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccEntitlementBasicPing (25.57s)
=== CONT  TestAccTrustedCertificateBasic
--- PASS: TestAccLocalUserBasic (25.93s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (26.77s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccAppgateTrustedCertificateDataSource (19.64s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccEntitlementUpdateActionHostOrder (45.25s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccAppgateMfaProviderDataSource (19.87s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (45.47s)
--- PASS: TestAccEntitlementBasicWithMonitor (46.34s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (20.90s)
--- PASS: TestAccEntitlementUpdateActionOrder (46.49s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (27.82s)
--- PASS: TestAccApplianceCustomizationBasic (24.08s)
--- PASS: TestAccApplianceBasicGateway (25.99s)
--- PASS: TestAccadministrativeRoleWithScope (25.08s)
--- PASS: TestAccadministrativeRoleBasic (25.15s)
--- PASS: TestAccApplianceConnector (26.29s)
--- PASS: TestAccTrustedCertificateBasic (24.63s)
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (24.31s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (27.91s)
--- PASS: TestAccRingfenceRuleBasicICMP (23.64s)
--- PASS: TestAccRingfenceRuleBasicTCP (11.23s)
--- PASS: TestAccAdminMfaSettingsBasic (10.85s)
--- PASS: TestAccPolicyBasic (11.34s)
--- PASS: TestAccSamlIdentityProviderBasic (58.79s)
--- PASS: TestAccSiteBasic (35.85s)
--- PASS: TestAccApplianceBasicController (38.19s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	103.897s
```