### PR TITLE
Client profile resource

### DIFF
--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -120,6 +120,7 @@ func Provider() *schema.Provider {
 			"appgatesdp_local_database_identity_provider":   resourceAppgateLocalDatabaseProvider(),
 			"appgatesdp_ldap_certificate_identity_provider": resourceAppgateLdapCertificateProvider(),
 			"appgatesdp_connector_identity_provider":        resourceAppgateConnectorProvider(),
+			"appgatesdp_client_profile":                     resourceAppgateClientProfile(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/appgate/resource_appgate_client_connections.go
+++ b/appgate/resource_appgate_client_connections.go
@@ -12,6 +12,9 @@ import (
 
 func resourceClientConnections() *schema.Resource {
 	return &schema.Resource{
+
+		DeprecationMessage: "Deprecated resource, replaced by appgatesdp_client_profile",
+
 		Create: resourceClientConnectionsCreate,
 		Read:   resourceClientConnectionsRead,
 		Update: resourceClientConnectionsUpdate,

--- a/appgate/resource_appgate_client_profile.go
+++ b/appgate/resource_appgate_client_profile.go
@@ -1,0 +1,230 @@
+package appgate
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/appgate/sdp-api-client-go/api/v14/openapi"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAppgateClientProfile() *schema.Resource {
+	return &schema.Resource{
+
+		Create: resourceAppgateClientProfileCreate,
+		Read:   resourceAppgateClientProfileRead,
+		Update: resourceAppgateClientProfileUpdate,
+		Delete: resourceAppgateClientProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		SchemaVersion: 1,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+
+			"spa_key_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"identity_provider_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func getIdFromProfile(profile openapi.ClientConnectionsProfiles) string {
+	// names are case sensitive and the controller only allows 1 per case type.
+	// so it will be suitable as the identitfer.
+	return profile.GetName()
+}
+
+func resourceAppgateClientProfileCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Create Client Profile %s", d.Get("name"))
+	ctx := context.Background()
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.ClientConnectionsApi
+
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		rand.Seed(time.Now().UnixNano())
+		duration := rand.Intn(10) // n will be between 0 and 20
+		log.Printf("[DEBUG] Create Client Profile %s Sleep %d", d.Get("name"), duration)
+		time.Sleep(time.Duration(duration) * time.Second)
+		if err := applianceStatsRetryable(ctx, meta); err != nil {
+			return err
+		}
+		clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
+		if err != nil {
+			return resource.RetryableError(err)
+		}
+		existingProfiles := clientConnections.GetProfiles()
+		log.Printf("[DEBUG] Create  %s -- existing profiles count %d", d.Get("name"), len(existingProfiles))
+		profile := openapi.ClientConnectionsProfiles{}
+		if v, ok := d.GetOk("name"); ok {
+			profile.SetName(v.(string))
+		}
+		if v, ok := d.GetOk("spa_key_name"); ok {
+			profile.SetSpaKeyName(v.(string))
+		}
+		if v, ok := d.GetOk("identity_provider_name"); ok {
+			profile.SetIdentityProviderName(v.(string))
+		}
+
+		d.SetId(getIdFromProfile(profile))
+
+		existingProfiles = append(existingProfiles, profile)
+		clientConnections.SetProfiles(existingProfiles)
+		_, response, err := api.ClientConnectionsPut(ctx).ClientConnections(clientConnections).Authorization(token).Execute()
+		if err != nil {
+			if response.StatusCode == http.StatusConflict {
+				return resource.RetryableError(fmt.Errorf("Expected client profile to be created but was in state %s", response.Status))
+			}
+			return resource.NonRetryableError(fmt.Errorf("Error updating client connection profiles: %s", err))
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error create: %s", err)
+	}
+	return resourceAppgateClientProfileRead(d, meta)
+}
+
+func resourceAppgateClientProfileRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Reading Client Profile id: %+v", d.Id())
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.ClientConnectionsApi
+	ctx := context.Background()
+	clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not read Client Connections %+v", prettyPrintAPIError(err))
+	}
+	existingProfiles := clientConnections.GetProfiles()
+	var p *openapi.ClientConnectionsProfiles
+	for _, profile := range existingProfiles {
+		if strings.EqualFold(profile.GetName(), d.Id()) && profile.GetName() == d.Id() {
+			p = &profile
+			d.Set("name", p.GetName())
+			d.Set("spa_key_name", p.GetSpaKeyName())
+			d.Set("identity_provider_name", p.GetIdentityProviderName())
+			d.Set("url", p.GetUrl())
+			break
+		}
+	}
+	if p == nil {
+		return fmt.Errorf("could not find client profile %s during read", d.Id())
+	}
+	return nil
+}
+
+func resourceAppgateClientProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Updating Client Profile %+v", d.Id())
+	ctx := context.Background()
+	token := meta.(*Client).Token
+	api := meta.(*Client).API.ClientConnectionsApi
+	clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not read Client Connections %+v", prettyPrintAPIError(err))
+	}
+	existingProfiles := clientConnections.GetProfiles()
+	var p *openapi.ClientConnectionsProfiles
+	for _, profile := range existingProfiles {
+		if strings.EqualFold(profile.GetName(), d.Id()) && profile.GetName() == d.Id() {
+			p = &profile
+			break
+		}
+	}
+	if p == nil {
+		diag.FromErr(fmt.Errorf("could not find client profile %s during update", d.Id()))
+	}
+
+	if d.HasChange("name") {
+		p.SetName(d.Get("name").(string))
+	}
+	if d.HasChange("spa_key_name") {
+		p.SetSpaKeyName(d.Get("spa_key_name").(string))
+	}
+	if d.HasChange("identity_provider_name") {
+		p.SetIdentityProviderName(d.Get("identity_provider_name").(string))
+	}
+	req := api.ClientConnectionsPut(ctx)
+	_, _, err = req.ClientConnections(clientConnections).Authorization(token).Execute()
+	if err != nil {
+		return fmt.Errorf("Could not update Client profile %s %+v", d.Id(), prettyPrintAPIError(err))
+	}
+	return resourceAppgateClientProfileRead(d, meta)
+}
+
+func resourceAppgateClientProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Delete client profile %+v", d.Id())
+	token := meta.(*Client).Token
+	ctx := context.Background()
+	api := meta.(*Client).API.ClientConnectionsApi
+
+	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		rand.Seed(time.Now().UnixNano())
+		duration := rand.Intn(10) // n will be between 0 and 20
+		log.Printf("[DEBUG] Create Client Profile %s Sleep %d", d.Get("name"), duration)
+		time.Sleep(time.Duration(duration) * time.Second)
+		if err := applianceStatsRetryable(ctx, meta); err != nil {
+			return err
+		}
+		clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
+		if err != nil {
+			return resource.RetryableError(fmt.Errorf("Could not read Client Connections during delete %+v", prettyPrintAPIError(err)))
+		}
+		existingProfiles := clientConnections.GetProfiles()
+		var p *openapi.ClientConnectionsProfiles
+		var newProfiles []openapi.ClientConnectionsProfiles
+		for i, profile := range existingProfiles {
+			if strings.EqualFold(profile.GetName(), d.Id()) && profile.GetName() == d.Id() {
+				p = &profile
+				// remove the profile from the list and maintain order.
+				newProfiles = append(existingProfiles[:i], existingProfiles[i+1:]...)
+
+				break
+			}
+		}
+		if p == nil {
+			diag.FromErr(fmt.Errorf("could not find client profile %s during delete", d.Id()))
+		}
+
+		clientConnections.SetProfiles(newProfiles)
+
+		_, _, err = api.ClientConnectionsPut(ctx).ClientConnections(clientConnections).Authorization(token).Execute()
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Could not delete Client Connections after retry %+v", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/appgate/resource_appgate_client_profile_test.go
+++ b/appgate/resource_appgate_client_profile_test.go
@@ -1,0 +1,84 @@
+package appgate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccClientProfileBasic(t *testing.T) {
+	resourceName := "appgatesdp_client_profile.test_client_profile"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckClientProfileBasic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClientProfileExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "hello"),
+					resource.TestCheckResourceAttr(resourceName, "spa_key_name", "world"),
+					resource.TestCheckResourceAttr(resourceName, "identity_provider_name", "local"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccClientProfileImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckClientProfileBasic() string {
+	return `
+resource "appgatesdp_client_profile" "test_client_profile" {
+	name                   = "hello"
+	spa_key_name           = "world"
+	identity_provider_name = "local"
+}
+`
+}
+
+func testAccCheckClientProfileExists(resource string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		token := testAccProvider.Meta().(*Client).Token
+		api := testAccProvider.Meta().(*Client).API.ClientConnectionsApi
+
+		rs, ok := state.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+		id := rs.Primary.ID
+		if id == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		clientConnections, _, err := api.ClientConnectionsGet(context.Background()).Authorization(token).Execute()
+		if err != nil {
+			return fmt.Errorf("error fetching ClientConnections with resource %s. %s", resource, err)
+		}
+
+		for _, profile := range clientConnections.GetProfiles() {
+			if strings.EqualFold(profile.GetName(), id) && profile.GetName() == id {
+				return nil
+			}
+
+		}
+		return fmt.Errorf("Could not find client connection.profile with name %s", id)
+	}
+}
+
+func testAccClientProfileImportStateCheckFunc(expectedStates int) resource.ImportStateCheckFunc {
+	return func(s []*terraform.InstanceState) error {
+		if len(s) != expectedStates {
+			return fmt.Errorf("expected %d states, got %d: %+v", expectedStates, len(s), s)
+		}
+		return nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.0
+	github.com/appgate/sdp-api-client-go v1.0.2-0.20210528124258-7e50abafde3e
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.6.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/appgate/sdp-api-client-go v1.0.0 h1:olRXcwVlzxOsphjqJI+ldej5ag6o5yrRyjbTedTH1+w=
 github.com/appgate/sdp-api-client-go v1.0.0/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.2-0.20210528124258-7e50abafde3e h1:W7j6fMyIV8/Iat0ri+9HHpWYamBaogbwcz29Ym/Kiws=
+github.com/appgate/sdp-api-client-go v1.0.2-0.20210528124258-7e50abafde3e/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/website/docs/r/client_connections.markdown
+++ b/website/docs/r/client_connections.markdown
@@ -10,6 +10,9 @@ description: |-
 
 Update Client Connection settings.
 
+~> **NOTE:** This resource has been replaced by [appgatesdp_client_profile](../r/client_profile.markdown) 
+
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/client_profile.markdown
+++ b/website/docs/r/client_profile.markdown
@@ -1,0 +1,44 @@
+---
+layout: "appgatesdp"
+page_title: "APPGATE: appgatesdp_client_profile"
+sidebar_current: "docs-appgate-resource-client-profile"
+description: |-
+   Update Client Connection settings. With API version 12, this API has changed significantly in order to manage client profiles. It is still possible to use the older APIs using older Accept headers.
+---
+
+# appgatesdp_client_profile
+
+Create or update client profile.
+
+
+## Example Usage
+
+```hcl
+
+resource "appgatesdp_client_profile" "test_uppercase" {
+  name                   = "development"
+  spa_key_name           = "development"
+  identity_provider_name = "local"
+}
+
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name`: (Required) A name to identify the client profile. It will appear on the client UI.
+* `spa_key_name`: (Required) SPA key name to be used in the profile. Same key names in different profiles will have the same SPA key. SPA key is used by the client to connect to the controllers.
+* `identity_provider_name`: (Required) Name of the Identity Provider to be used to authenticate.
+* `url`:  (Computed) Connection URL for the profile.
+
+
+
+## Import
+
+Instances can be imported using the `name`, e.g.
+
+```
+$ terraform import appgatesdp_client_profile development
+```


### PR DESCRIPTION
New resource `appgatesdp_client_profile`, this will replace `appgatesdp_client_connections`. This for easier handling the  state and control CRUD operations of Client Profiles. This will mitigate errors seen in https://github.com/appgate/terraform-provider-appgatesdp/issues/123

acceptance test on 5.`3.2-23587-release`


```

make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
--- PASS: TestConfig (0.01s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (11.00s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (3.72s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.63s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.65s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.92s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (6.21s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
=== PAUSE TestAccClientConnectionsBasic
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.94s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.89s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccSiteBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (19.90s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccRingfenceRuleBasicICMP (23.12s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccDeviceScriptBasic (23.60s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccAdminMfaSettingsBasic (23.88s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccLocalUserBasic (24.48s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccRingfenceRuleBasicTCP (24.68s)
=== CONT  TestAccClientConnectionsBasic
--- PASS: TestAccCriteriaScriptBasic (25.09s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccGlobalSettingsBasic (25.27s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccIPPoolBasic (25.40s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccPolicyBasic (25.50s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccTrustedCertificateBasic (25.51s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (25.68s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (25.75s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccMfaProviderBasic (26.11s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccConditionBasic (26.34s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccLdapIdentityProviderBasic (26.57s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccRadiusIdentityProviderBasic (27.02s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccAppgateTrustedCertificateDataSource (19.41s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccAppgateMfaProviderDataSource (20.01s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccEntitlementBasicPing (26.01s)
--- PASS: TestAccBlacklistUserBasic (25.45s)
--- PASS: TestAccApplianceCustomizationBasic (25.29s)
--- PASS: TestAccadministrativeRoleBasic (25.45s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (26.74s)
--- PASS: TestAccApplianceBasicGateway (26.55s)
--- PASS: TestAccClientConnectionsBasic (28.16s)
--- PASS: TestAccApplianceConnector (27.52s)
--- PASS: TestAccadministrativeRoleWithScope (27.16s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (28.23s)
--- PASS: TestAccSiteBasic (58.03s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (12.79s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (39.51s)
--- PASS: TestAccEntitlementUpdateActionOrder (36.49s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (37.56s)
--- PASS: TestAccEntitlementScriptBasic (13.69s)
--- PASS: TestAccEntitlementBasicWithMonitor (36.95s)
--- PASS: TestAccSamlIdentityProviderBasic (61.66s)
--- PASS: TestAccApplianceBasicController (39.44s)
--- PASS: TestAccClientProfileBasic (75.64s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	117.668s
```