### PR TITLE
Admin role 129

### DIFF
--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -62,80 +62,11 @@ func resourceAppgateAdministrativeRole() *schema.Resource {
 						"type": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: func(v interface{}, name string) (warns []string, errs []error) {
-								s := v.(string)
-								list := []string{
-									"All",
-									"View",
-									"Create",
-									"Edit",
-									"Tag",
-									"Delete",
-									"Revoke",
-									"Export",
-									"Upgrade",
-									"RenewCertificate",
-									"DownloadLogs",
-									"Test",
-									"GetUserAttributes",
-									"Backup",
-									"CheckStatus",
-									"Reevaluate",
-								}
-								for _, x := range list {
-									if s == x {
-										return
-									}
-								}
-								errs = append(errs, fmt.Errorf("type must be on of %v, got %s", list, s))
-								return
-							},
 						},
 
 						"target": {
 							Type:     schema.TypeString,
 							Required: true,
-							ValidateFunc: func(v interface{}, name string) (warns []string, errs []error) {
-								s := v.(string)
-								list := []string{
-									"All",
-									"Appliance",
-									"Condition",
-									"CriteriaScript",
-									"Entitlement",
-									"AdministrativeRole",
-									"IdentityProvider",
-									"MfaProvider",
-									"IpPool",
-									"LocalUser",
-									"Policy",
-									"Site",
-									"DeviceScript",
-									"EntitlementScript",
-									"RingfenceRule",
-									"ApplianceCustomization",
-									"OtpSeed",
-									"TokenRecord",
-									"Blacklist",
-									"UserLicense",
-									"RegisteredDevice",
-									"AllocatedIp",
-									"SessionInfo",
-									"AuditLog",
-									"AdminMessage",
-									"GlobalSetting",
-									"CaCertificate",
-									"File",
-									"FailedAuthentication",
-								}
-								for _, x := range list {
-									if s == x {
-										return
-									}
-								}
-								errs = append(errs, fmt.Errorf("type must be on of %v, got %s", list, s))
-								return
-							},
 						},
 
 						"scope": {

--- a/appgate/resource_appgate_administrative_role_test.go
+++ b/appgate/resource_appgate_administrative_role_test.go
@@ -190,3 +190,137 @@ func testAccadministrativeRoleImportStateCheckFunc(expectedStates int) resource.
 		return nil
 	}
 }
+
+func TestAccadministrativeMultiplePrivilegesValidation(t *testing.T) {
+	resourceName := "appgatesdp_administrative_role.test_administrative_role_129"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":   rName,
+		"target": "RegisteredDevice", // from >= 5.3 its called RegisteredDevice, prior to 5.3 it was called OnBoardedDevice
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckadministrativeRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					if currentVersion.LessThan(Appliance53Version) {
+						t.Skip("Test only for 5.3 and above, privileges.target RegisteredDevice not supported prior to 5.3")
+					}
+				},
+				Config: testAccCheckadministrativeRoleMultiplePrivlegesConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckadministrativeRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.0.all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.target", context["target"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.type", "View"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.0.all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.target", context["target"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.type", "Delete"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "aa"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "bb"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "cc"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccadministrativeRoleImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+// TestAccadministrativeMultiplePrivilegesValidation52 make sure it still works on 5.2
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/129
+func TestAccadministrativeMultiplePrivilegesValidation52(t *testing.T) {
+	resourceName := "appgatesdp_administrative_role.test_administrative_role_129"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":   rName,
+		"target": "OnBoardedDevice", // in < 5.3 its called OnBoardedDevice
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckadministrativeRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					if currentVersion.GreaterThanOrEqual(Appliance53Version) {
+						t.Skip("Test is only for 5.2, privileges.target OnBoardedDevice")
+					}
+				},
+				Config: testAccCheckadministrativeRoleMultiplePrivlegesConfig(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckadministrativeRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.scope.0.all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.target", context["target"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "privileges.0.type", "View"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.scope.0.all", "true"),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.target", context["target"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "privileges.1.type", "Delete"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "aa"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "bb"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "cc"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccadministrativeRoleImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckadministrativeRoleMultiplePrivlegesConfig(context map[string]interface{}) string {
+	// Test based on https://github.com/appgate/terraform-provider-appgatesdp/issues/129#issuecomment-852211335
+	return Nprintf(`
+resource "appgatesdp_administrative_role" "test_administrative_role_129" {
+	name  = "%{name}"
+	tags  = ["aa", "bb", "cc"]
+	
+	privileges {
+		type   = "View"
+		target = "%{target}"
+	
+		scope {
+		all = true
+		}
+	}
+	
+	privileges {
+		type   = "Delete"
+		target = "%{target}"
+	
+		scope {
+		all = true
+		}
+	}
+}
+`, context)
+}


### PR DESCRIPTION
Remove validation in the terraform provider for `privileges.target` and `privileges.type` and rely on server side validation instead. added regression test for https://github.com/appgate/terraform-provider-appgatesdp/issues/129#issuecomment-852211335

in 5.2, `OnBoardedDevice` is a valid target, and in 5.3 and above its called `RegisteredDevice`

administrative role acceptance test on 5.2.4-24406-release

```bash
TF_ACC=1 \                      
go test -v -timeout 120m github.com/appgate/terraform-provider-appgatesdp/appgate -run '^(TestAccadministrativeMultiplePrivileges*.+)$'
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
    resource_appgate_administrative_role_test.go:210: Test only for 5.3 and above, privileges.target RegisteredDevice not supported prior to 5.3
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation (0.98s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation52 (7.56s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	7.586s
```

acceptance test for 5.3.2-23587-release

<details>

```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.02s)
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.07s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (3.91s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.90s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.87s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (4.16s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (4.03s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (7.90s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (32.31s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.36s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccSiteBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (19.88s)
--- PASS: TestAccRingfenceRuleBasicTCP (22.84s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccPolicyBasic (23.40s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccIPPoolBasic (25.36s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccMfaProviderBasic (26.68s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccEntitlementScriptBasic (26.73s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccConditionBasic (26.94s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccAdminMfaSettingsBasic (27.04s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccLocalUserBasic (27.26s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccEntitlementBasicPing (28.12s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccCriteriaScriptBasic (28.23s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccDeviceScriptBasic (28.34s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccRingfenceRuleBasicICMP (28.39s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (28.50s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccTrustedCertificateBasic (28.65s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccRadiusIdentityProviderBasic (30.13s)
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:265: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (4.61s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccApplianceCustomizationBasic (41.94s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccBlacklistUserBasic (25.92s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccApplianceConnector (25.87s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (29.32s)
--- PASS: TestAccEntitlementBasicWithMonitor (53.30s)
--- PASS: TestAccAppgateMfaProviderDataSource (21.05s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (29.66s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (26.48s)
--- PASS: TestAccGlobalSettingsBasic (26.94s)
--- PASS: TestAccadministrativeRoleBasic (27.25s)
--- PASS: TestAccLdapIdentityProviderBasic (28.43s)
--- PASS: TestAccApplianceBasicGateway (29.26s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (28.29s)
--- PASS: TestAccadministrativeRoleWithScope (26.67s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (17.04s)
--- PASS: TestAccSiteBasic (62.23s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (11.04s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (36.40s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (38.53s)
--- PASS: TestAccSamlIdentityProviderBasic (66.58s)
--- PASS: TestAccEntitlementUpdateActionOrder (20.40s)
--- PASS: TestAccApplianceBasicController (43.11s)
--- PASS: TestAccClientProfileBasic (52.78s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	148.246s

```

</details>
