### PR TITLE
updated site short_name

### DIFF
--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -793,7 +793,9 @@ func resourceAppgateSiteUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("name") {
 		orginalSite.SetName(d.Get("name").(string))
 	}
-
+	if d.HasChange("short_name") {
+		orginalSite.SetShortName(d.Get("short_name").(string))
+	}
 	if d.HasChange("tags") {
 		orginalSite.SetTags(schemaExtractTags(d))
 	}

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -74,7 +74,7 @@ func TestAccSiteBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "network_subnets.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "network_subnets.0", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "notes", "This object has been created for test purposes."),
-					resource.TestCheckResourceAttr(resourceName, "short_name", "tst"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", "ts0"),
 
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
@@ -101,6 +101,7 @@ func TestAccSiteBasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSiteExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", "The test site"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", "ts1"),
 					resource.TestCheckResourceAttr(resourceName, "network_subnets.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "network_subnets.0", "10.0.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "network_subnets.1", "10.20.0.0/24"),
@@ -163,7 +164,7 @@ func testAccCheckSite(rName string) string {
 	return fmt.Sprintf(`
 resource "appgatesdp_site" "test_site" {
     name       = "%s"
-    short_name = "tst"
+    short_name = "ts0"
     tags = [
         "developer",
         "api-created"
@@ -243,7 +244,7 @@ func testAccCheckSiteUpdate() string {
 	return `
 resource "appgatesdp_site" "test_site" {
     name       = "The test site"
-    short_name = "tst"
+    short_name = "ts1"
     tags = [
         "developer",
         "api-created",


### PR DESCRIPTION
fixed missing update check, this PR resolves #138 







<details>

tested on appliance 5.3.2-23587-release
```bash
> terraform version                                                                  
Terraform v1.0.2
on linux_amd64

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/test_before_5.4
=== RUN   TestConfig/test_5.4_login
=== RUN   TestConfig/invalid_client_version
--- PASS: TestConfig (0.00s)
    --- PASS: TestConfig/test_before_5.4 (0.00s)
    --- PASS: TestConfig/test_5.4_login (0.00s)
    --- PASS: TestConfig/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (7.33s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.99s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.03s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.01s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.26s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.26s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.60s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.13s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.21s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccSiteBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (10.19s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccRingfenceRuleBasicICMP (11.58s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (11.90s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccIPPoolBasic (11.94s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccAdminMfaSettingsBasic (12.51s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccTrustedCertificateBasic (12.53s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccRingfenceRuleBasicTCP (12.78s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccRadiusIdentityProviderBasic (13.01s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccPolicyBasic (13.13s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccGlobalSettingsBasic (13.13s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccEntitlementBasicPing (13.14s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (13.14s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccLocalUserBasic (13.28s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccLdapIdentityProviderBasic (13.85s)
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2161: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.95s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccEntitlementUpdateActionOrder (22.43s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccEntitlementBasicWithMonitor (23.02s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccEntitlementUpdateActionHostOrder (23.33s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccMfaProviderBasic (13.21s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (23.86s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccDeviceScriptBasic (11.97s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:264: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccApplianceBasicGateway (12.91s)
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (2.09s)
--- PASS: TestAccCriteriaScriptBasic (12.02s)
--- PASS: TestAccEntitlementScriptBasic (12.70s)
--- PASS: TestAccConditionBasic (12.48s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (12.00s)
--- PASS: TestAccBlacklistUserBasic (12.45s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (13.20s)
--- PASS: TestAccApplianceConnector (13.45s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (13.73s)
--- PASS: TestAccSiteBasic (30.06s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.24s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (6.72s)
--- PASS: TestAccApplianceCustomizationBasic (15.64s)
--- PASS: TestAccAppgateMfaProviderDataSource (6.89s)
--- PASS: TestAccadministrativeRoleBasic (7.98s)
--- PASS: TestAccadministrativeRoleWithScope (8.20s)
--- PASS: TestAccSamlIdentityProviderBasic (32.42s)
--- PASS: TestAccApplianceBasicController (21.44s)
--- PASS: TestAccClientProfileBasic (34.18s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	81.824s
```


</details>




<details>

tested on appliance 5.4.2-25318-beta
```bash
> terraform version                                                                  
Terraform v1.0.2
on linux_amd64

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/test_before_5.4
=== RUN   TestConfig/test_5.4_login
=== RUN   TestConfig/invalid_client_version
--- PASS: TestConfig (0.00s)
    --- PASS: TestConfig/test_before_5.4 (0.00s)
    --- PASS: TestConfig/test_5.4_login (0.00s)
    --- PASS: TestConfig/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.57s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (3.67s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.16s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.49s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (4.08s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.46s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (4.20s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.54s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.83s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccApplianceConnector
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccAppgateApplianceCustomizationDataSource
=== CONT  TestAccSiteBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:264: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (2.62s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccAppgateTrustedCertificateDataSource (12.89s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccLocalUserBasic (13.67s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (13.98s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (14.14s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccAppgateMfaProviderDataSource (14.29s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccadministrativeRoleBasic (14.46s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccIPPoolBasic (14.62s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (15.06s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccEntitlementBasicPing (15.36s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccApplianceConnector (15.40s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccadministrativeRoleWithScope (15.47s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccTrustedCertificateBasic (15.71s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (15.82s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccApplianceBasicGateway (16.31s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccRadiusIdentityProviderBasic (16.67s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccRingfenceRuleBasicTCP (14.56s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccApplianceCustomizationBasic (23.71s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccRingfenceRuleBasicICMP (13.27s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccGlobalSettingsBasic (13.06s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccPolicyBasic (14.22s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccAdminMfaSettingsBasic (13.99s)
--- PASS: TestAccMfaProviderBasic (14.05s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (14.02s)
--- PASS: TestAccLdapIdentityProviderBasic (15.31s)
--- PASS: TestAccCriteriaScriptBasic (13.05s)
--- PASS: TestAccDeviceScriptBasic (13.46s)
--- PASS: TestAccEntitlementScriptBasic (14.05s)
--- PASS: TestAccConditionBasic (13.65s)
--- PASS: TestAccSiteBasic (34.21s)
--- PASS: TestAccBlacklistUserBasic (8.88s)
--- PASS: TestAccClientProfileBasic (19.59s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (11.66s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (20.82s)
--- PASS: TestAccApplianceBasicController (36.13s)
--- PASS: TestAccEntitlementUpdateActionOrder (20.77s)
--- PASS: TestAccEntitlementBasicWithMonitor (20.88s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (21.05s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (9.02s)
--- PASS: TestAccSamlIdentityProviderBasic (37.68s)
--- PASS: TestAccAppliancePortalSetup (30.18s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	98.874s


```

</details>
