### PR TITLE
resource appliance correctly read from remote. 

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -1280,7 +1280,7 @@ func readNetworkNicsFromConfig(hosts []interface{}) ([]openapi.ApplianceAllOfNet
 				if item := ipv4Data["static"]; len(item.([]interface{})) > 0 {
 					ipv4networking.SetStatic(readNetworkIpv4StaticFromConfig(item.([]interface{})))
 				}
-				if v, o := ipv4Data["virtual_ip"]; o && len(v.(string)) > 0 {
+				if v, ok := ipv4Data["virtual_ip"]; ok && len(v.(string)) > 0 {
 					ipv4networking.SetVirtualIp(v.(string))
 				}
 			}
@@ -1299,7 +1299,7 @@ func readNetworkNicsFromConfig(hosts []interface{}) ([]openapi.ApplianceAllOfNet
 				if v := ipv6Data["static"]; len(v.([]interface{})) > 0 {
 					ipv6networking.SetStatic(readNetworkIpv6StaticFromConfig(v.([]interface{})))
 				}
-				if v, o := ipv6Data["virtual_ip"]; o && len(v.(string)) > 0 {
+				if v, ok := ipv6Data["virtual_ip"]; ok && len(v.(string)) > 0 {
 					ipv6networking.SetVirtualIp(v.(string))
 				}
 			}
@@ -1484,7 +1484,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("connect_to_peers_using_client_port_with_spa", appliance.GetConnectToPeersUsingClientPortWithSpa())
 
-	if v, o := appliance.GetClientInterfaceOk(); o != false {
+	if v, ok := appliance.GetClientInterfaceOk(); ok {
 		ci, err := flattenApplianceClientInterface(*v)
 		if err != nil {
 			return err
@@ -1492,7 +1492,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("client_interface", ci)
 	}
 
-	if v, o := appliance.GetPeerInterfaceOk(); o != false {
+	if v, ok := appliance.GetPeerInterfaceOk(); ok {
 		peerInterface, err := flattenAppliancePeerInterface(*v)
 		if err != nil {
 			return err
@@ -1500,7 +1500,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		d.Set("peer_interface", peerInterface)
 	}
 
-	if v, o := appliance.GetAdminInterfaceOk(); o != false {
+	if v, ok := appliance.GetAdminInterfaceOk(); ok {
 		adminInterface, err := flattenApplianceAdminInterface(*v)
 		if err != nil {
 			return err
@@ -1510,7 +1510,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if v, o := appliance.GetNetworkingOk(); o != false {
+	if v, ok := appliance.GetNetworkingOk(); ok {
 		networking, err := flattenApplianceNetworking(*v)
 		if err != nil {
 			return err
@@ -1520,7 +1520,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("ntp"); o {
+	if _, ok := d.GetOkExists("ntp"); ok {
 		v := appliance.GetNtp()
 		ntp := make(map[string]interface{})
 		servers := make([]map[string]interface{}, 0)
@@ -1537,7 +1537,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("ssh_server"); o {
+	if _, ok := d.GetOkExists("ssh_server"); ok {
 		v := appliance.GetSshServer()
 		sshServer := make(map[string]interface{})
 		sshServer["enabled"] = v.GetEnabled()
@@ -1550,7 +1550,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("snmp_server"); o {
+	if _, ok := d.GetOkExists("snmp_server"); ok {
 		v := appliance.GetSnmpServer()
 		snmpSrv := make(map[string]interface{})
 		snmpSrv["enabled"] = v.GetEnabled()
@@ -1564,7 +1564,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("healthcheck_server"); o {
+	if _, ok := d.GetOkExists("healthcheck_server"); ok {
 		v := appliance.GetHealthcheckServer()
 		healthSrv := make(map[string]interface{})
 		healthSrv["enabled"] = v.GetEnabled()
@@ -1576,7 +1576,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("prometheus_exporter"); o {
+	if _, ok := d.GetOkExists("prometheus_exporter"); ok {
 		v := appliance.GetPrometheusExporter()
 		exporter := make(map[string]interface{})
 		exporter["enabled"] = v.GetEnabled()
@@ -1588,7 +1588,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("ping"); o {
+	if _, ok := d.GetOkExists("ping"); ok {
 		v := appliance.GetPing()
 		ping := make(map[string]interface{})
 		ping["allow_sources"] = v.GetAllowSources()
@@ -1598,7 +1598,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("log_server"); o {
+	if _, ok := d.GetOkExists("log_server"); ok {
 		v := appliance.GetLogServer()
 		logsrv := make(map[string]interface{})
 		logsrv["enabled"] = v.GetEnabled()
@@ -1609,7 +1609,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("controller"); o {
+	if _, ok := d.GetOkExists("controller"); ok {
 		v := appliance.GetController()
 		ctrl := make(map[string]interface{})
 		ctrl["enabled"] = v.GetEnabled()
@@ -1619,7 +1619,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("gateway"); o {
+	if _, ok := d.GetOkExists("gateway"); ok {
 		gateway, err := flatttenApplianceGateway(appliance.GetGateway())
 		if err != nil {
 			return err
@@ -1629,7 +1629,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("log_forwarder"); o {
+	if _, ok := d.GetOkExists("log_forwarder"); ok {
 		logforward, err := flatttenApplianceLogForwarder(appliance.GetLogForwarder())
 		if err != nil {
 			return err
@@ -1639,7 +1639,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if _, o := d.GetOkExists("connector"); o {
+	if _, ok := d.GetOkExists("connector"); ok {
 		iot, err := flatttenApplianceConnector(currentVersion, appliance.GetConnector())
 		if err != nil {
 			return err
@@ -1649,7 +1649,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if v, o := appliance.GetRsyslogDestinationsOk(); o != false {
+	if v, ok := appliance.GetRsyslogDestinationsOk(); ok {
 		rsyslogs := make([]map[string]interface{}, 0)
 		for _, rsys := range *v {
 			rsyslog := make(map[string]interface{})
@@ -1696,7 +1696,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if v, o := appliance.GetHostnameAliasesOk(); o != false {
+	if v, ok := appliance.GetHostnameAliasesOk(); ok {
 		if err := d.Set("hostname_aliases", v); err != nil {
 			return err
 		}
@@ -1748,16 +1748,16 @@ func flattenApplianceProxyp12s(local map[string]interface{}, p12 openapi.P12) ([
 func flatttenApplianceGateway(in openapi.ApplianceAllOfGateway) ([]map[string]interface{}, error) {
 	var gateways []map[string]interface{}
 	gateway := make(map[string]interface{})
-	if v, o := in.GetEnabledOk(); o != false {
+	if v, ok := in.GetEnabledOk(); ok {
 		gateway["enabled"] = v
 	}
 
-	if v, o := in.GetVpnOk(); o != false {
+	if v, ok := in.GetVpnOk(); ok {
 		vpn := make(map[string]interface{})
-		if v, o := v.GetWeightOk(); o {
+		if v, ok := v.GetWeightOk(); ok {
 			vpn["weight"] = *v
 		}
-		if v, o := v.GetAllowDestinationsOk(); o {
+		if v, ok := v.GetAllowDestinationsOk(); ok {
 			destinations := make([]map[string]interface{}, 0)
 			for _, d := range *v {
 				destination := make(map[string]interface{})
@@ -1778,33 +1778,33 @@ func flatttenApplianceGateway(in openapi.ApplianceAllOfGateway) ([]map[string]in
 func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder) ([]map[string]interface{}, error) {
 	var logforwarders []map[string]interface{}
 	logforward := make(map[string]interface{})
-	if v, o := in.GetEnabledOk(); o != false {
+	if v, ok := in.GetEnabledOk(); ok {
 		logforward["enabled"] = *v
 	}
 
-	if v, o := in.GetElasticsearchOk(); o != false {
+	if v, ok := in.GetElasticsearchOk(); ok {
 		elasticsearch := make(map[string]interface{})
-		if v, o := v.GetUrlOk(); o != false {
+		if v, ok := v.GetUrlOk(); ok {
 			elasticsearch["url"] = *v
 		}
-		if v, o := v.GetAwsIdOk(); o != false {
+		if v, ok := v.GetAwsIdOk(); ok {
 			elasticsearch["aws_id"] = *v
 		}
-		if v, o := v.GetAwsSecretOk(); o != false {
+		if v, ok := v.GetAwsSecretOk(); ok {
 			elasticsearch["aws_secret"] = *v
 		}
-		if v, o := v.GetAwsRegionOk(); o != false {
+		if v, ok := v.GetAwsRegionOk(); ok {
 			elasticsearch["aws_region"] = *v
 		}
-		if v, o := v.GetUseInstanceCredentialsOk(); o != false {
+		if v, ok := v.GetUseInstanceCredentialsOk(); ok {
 			elasticsearch["use_instance_credentials"] = *v
 		}
-		if v, o := v.GetRetentionDaysOk(); o != false {
+		if v, ok := v.GetRetentionDaysOk(); ok {
 			elasticsearch["retention_days"] = *v
 		}
 		logforward["elasticsearch"] = []map[string]interface{}{elasticsearch}
 	}
-	if v, o := in.GetTcpClientsOk(); o != false {
+	if v, ok := in.GetTcpClientsOk(); ok {
 		tcpClientList := make([]map[string]interface{}, 0)
 		for _, tcpClient := range *v {
 			client := make(map[string]interface{})
@@ -1818,7 +1818,7 @@ func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder) ([]map
 		}
 		logforward["tcp_clients"] = tcpClientList
 	}
-	if v, o := in.GetAwsKinesesOk(); o != false {
+	if v, ok := in.GetAwsKinesesOk(); ok {
 		kinesesList := make([]map[string]interface{}, 0)
 		for _, kineses := range *v {
 			k := make(map[string]interface{})
@@ -1844,10 +1844,10 @@ func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder) ([]map
 func flatttenApplianceConnector(currentVersion *version.Version, in openapi.ApplianceAllOfConnector) ([]map[string]interface{}, error) {
 	var connectors []map[string]interface{}
 	connector := make(map[string]interface{})
-	if v, o := in.GetEnabledOk(); o != false {
+	if v, ok := in.GetEnabledOk(); ok {
 		connector["enabled"] = *v
 	}
-	if v, o := in.GetExpressClientsOk(); o != false {
+	if v, ok := in.GetExpressClientsOk(); ok {
 		clients := make([]map[string]interface{}, 0)
 		for _, client := range *v {
 			c := make(map[string]interface{})
@@ -1870,7 +1870,7 @@ func flatttenApplianceConnector(currentVersion *version.Version, in openapi.Appl
 		}
 		connector["express_clients"] = clients
 	}
-	if v, o := in.GetAdvancedClientsOk(); o != false {
+	if v, ok := in.GetAdvancedClientsOk(); ok {
 		clients := make([]map[string]interface{}, 0)
 		for _, client := range *v {
 			c := make(map[string]interface{})
@@ -1893,19 +1893,19 @@ func flatttenApplianceConnector(currentVersion *version.Version, in openapi.Appl
 
 func flattenApplianceClientInterface(in openapi.ApplianceAllOfClientInterface) ([]interface{}, error) {
 	m := make(map[string]interface{})
-	if v, o := in.GetProxyProtocolOk(); o != false {
+	if v, ok := in.GetProxyProtocolOk(); ok {
 		m["proxy_protocol"] = *v
 	}
-	if v, o := in.GetHostnameOk(); o != false {
+	if v, ok := in.GetHostnameOk(); ok {
 		m["hostname"] = *v
 	}
-	if v, o := in.GetHttpsPortOk(); o != false {
+	if v, ok := in.GetHttpsPortOk(); ok {
 		m["https_port"] = *v
 	}
-	if v, o := in.GetDtlsPortOk(); o != false {
+	if v, ok := in.GetDtlsPortOk(); ok {
 		m["dtls_port"] = *v
 	}
-	if _, o := in.GetAllowSourcesOk(); o != false {
+	if _, ok := in.GetAllowSourcesOk(); ok {
 		allowSources, err := readAllowSourcesFromConfig(in.GetAllowSources())
 		if err != nil {
 			return nil, err
@@ -1913,7 +1913,7 @@ func flattenApplianceClientInterface(in openapi.ApplianceAllOfClientInterface) (
 		m["allow_sources"] = allowSources
 	}
 
-	if v, o := in.GetOverrideSpaModeOk(); o != false {
+	if v, ok := in.GetOverrideSpaModeOk(); ok {
 		m["override_spa_mode"] = v
 	} else {
 		// If we dont get any from the response body, we will manually set it to Disabled to
@@ -1927,13 +1927,13 @@ func flattenApplianceClientInterface(in openapi.ApplianceAllOfClientInterface) (
 
 func flattenAppliancePeerInterface(in openapi.ApplianceAllOfPeerInterface) ([]interface{}, error) {
 	m := make(map[string]interface{})
-	if v, o := in.GetHostnameOk(); o != false {
+	if v, ok := in.GetHostnameOk(); ok {
 		m["hostname"] = v
 	}
-	if v, o := in.GetHttpsPortOk(); o != false {
+	if v, ok := in.GetHttpsPortOk(); ok {
 		m["https_port"] = v
 	}
-	if _, o := in.GetAllowSourcesOk(); o != false {
+	if _, ok := in.GetAllowSourcesOk(); ok {
 		allowSources, err := readAllowSourcesFromConfig(in.GetAllowSources())
 		if err != nil {
 			return nil, err
@@ -1945,17 +1945,17 @@ func flattenAppliancePeerInterface(in openapi.ApplianceAllOfPeerInterface) ([]in
 
 func flattenApplianceAdminInterface(in openapi.ApplianceAllOfAdminInterface) ([]interface{}, error) {
 	m := make(map[string]interface{})
-	if v, o := in.GetHostnameOk(); o != false {
+	if v, ok := in.GetHostnameOk(); ok {
 		m["hostname"] = *v
 	}
-	if v, o := in.GetHttpsPortOk(); o != false {
+	if v, ok := in.GetHttpsPortOk(); ok {
 		m["https_port"] = *v
 	}
-	if v, o := in.GetHttpsCiphersOk(); o != false {
+	if v, ok := in.GetHttpsCiphersOk(); ok {
 		m["https_ciphers"] = *v
 	}
 
-	if _, o := in.GetAllowSourcesOk(); o != false {
+	if _, ok := in.GetAllowSourcesOk(); ok {
 		allowSources, err := readAllowSourcesFromConfig(in.GetAllowSources())
 		if err != nil {
 			return nil, err
@@ -1969,14 +1969,14 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 	var networkings []map[string]interface{}
 	networking := make(map[string]interface{})
 
-	if v, o := in.GetHostsOk(); o != false {
+	if v, ok := in.GetHostsOk(); ok {
 		hosts := make([]map[string]interface{}, 0)
 		for _, h := range *v {
 			host := make(map[string]interface{})
-			if v, o := h.GetAddressOk(); o != false {
+			if v, ok := h.GetAddressOk(); ok {
 				host["address"] = *v
 			}
-			if v, o := h.GetHostnameOk(); o != false {
+			if v, ok := h.GetHostnameOk(); ok {
 				host["hostname"] = *v
 			}
 			hosts = append(hosts, host)
@@ -1984,46 +1984,46 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 		networking["hosts"] = hosts
 	}
 
-	if v, o := in.GetNicsOk(); o != false {
+	if v, ok := in.GetNicsOk(); ok {
 		nics := make([]map[string]interface{}, 0)
 		for _, h := range *v {
 			nic := make(map[string]interface{})
-			if v, o := h.GetEnabledOk(); o != false {
+			if v, ok := h.GetEnabledOk(); ok {
 				nic["enabled"] = *v
 			}
-			if v, o := h.GetNameOk(); o != false {
+			if v, ok := h.GetNameOk(); ok {
 				nic["name"] = *v
 			}
-			if v, o := h.GetMtuOk(); o != false {
+			if v, ok := h.GetMtuOk(); ok {
 				nic["mtu"] = *v
 			}
 
-			if v, o := h.GetIpv4Ok(); o != false {
+			if v, ok := h.GetIpv4Ok(); ok {
 				dhcp := make(map[string]interface{})
 				staticList := make([]map[string]interface{}, 0)
 				dhcpValue := v.GetDhcp()
 
-				if v, o := dhcpValue.GetEnabledOk(); o != false {
+				if v, ok := dhcpValue.GetEnabledOk(); ok {
 					dhcp["enabled"] = *v
 				}
-				if v, o := dhcpValue.GetDnsOk(); o != false {
+				if v, ok := dhcpValue.GetDnsOk(); ok {
 					dhcp["dns"] = *v
 				}
-				if v, o := dhcpValue.GetRoutersOk(); o != false {
+				if v, ok := dhcpValue.GetRoutersOk(); ok {
 					dhcp["routers"] = *v
 				}
-				if v, o := dhcpValue.GetNtpOk(); o != false {
+				if v, ok := dhcpValue.GetNtpOk(); ok {
 					dhcp["ntp"] = *v
 				}
 				for _, s := range v.GetStatic() {
 					static := make(map[string]interface{})
-					if v, o := s.GetAddressOk(); o {
+					if v, ok := s.GetAddressOk(); ok {
 						static["address"] = *v
 					}
-					if v, o := s.GetNetmaskOk(); o {
+					if v, ok := s.GetNetmaskOk(); ok {
 						static["netmask"] = *v
 					}
-					if v, o := s.GetSnatOk(); o {
+					if v, ok := s.GetSnatOk(); ok {
 						static["snat"] = *v
 					}
 					staticList = append(staticList, static)
@@ -2031,34 +2031,34 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 				ipv4map := make(map[string]interface{})
 				ipv4map["dhcp"] = []map[string]interface{}{dhcp}
 				ipv4map["static"] = staticList
-				if v, o := v.GetVirtualIpOk(); o && len(*v) > 0 {
+				if v, ok := v.GetVirtualIpOk(); ok && len(*v) > 0 {
 					ipv4map["virtual_ip"] = *v
 				}
 				nic["ipv4"] = []map[string]interface{}{ipv4map}
 			}
-			if v, o := h.GetIpv6Ok(); o != false {
+			if v, ok := h.GetIpv6Ok(); ok {
 				dhcp := make(map[string]interface{})
 				staticList := make([]map[string]interface{}, 0)
 				dhcpValue := v.GetDhcp()
-				if v, o := dhcpValue.GetEnabledOk(); o != false {
+				if v, ok := dhcpValue.GetEnabledOk(); ok {
 					dhcp["enabled"] = *v
 				}
-				if v, o := dhcpValue.GetDnsOk(); o != false {
+				if v, ok := dhcpValue.GetDnsOk(); ok {
 					dhcp["dns"] = *v
 				}
 
-				if v, o := dhcpValue.GetNtpOk(); o != false {
+				if v, ok := dhcpValue.GetNtpOk(); ok {
 					dhcp["ntp"] = *v
 				}
 				for _, s := range v.GetStatic() {
 					static := make(map[string]interface{})
-					if v, o := s.GetAddressOk(); o {
+					if v, ok := s.GetAddressOk(); ok {
 						static["address"] = *v
 					}
-					if v, o := s.GetNetmaskOk(); o {
+					if v, ok := s.GetNetmaskOk(); ok {
 						static["netmask"] = *v
 					}
-					if v, o := s.GetSnatOk(); o {
+					if v, ok := s.GetSnatOk(); ok {
 						static["snat"] = *v
 					}
 					staticList = append(staticList, static)
@@ -2066,7 +2066,7 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 				ipv6map := make(map[string]interface{})
 				ipv6map["dhcp"] = []map[string]interface{}{dhcp}
 				ipv6map["static"] = staticList
-				if v, o := v.GetVirtualIpOk(); o && len(*v) > 0 {
+				if v, ok := v.GetVirtualIpOk(); ok && len(*v) > 0 {
 					ipv6map["virtual_ip"] = *v
 				}
 				nic["ipv6"] = []map[string]interface{}{ipv6map}
@@ -2076,26 +2076,26 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 		}
 		networking["nics"] = nics
 	}
-	if v, o := in.GetDnsServersOk(); o {
+	if v, ok := in.GetDnsServersOk(); ok {
 		networking["dns_servers"] = *v
 	}
-	if v, o := in.GetDnsDomainsOk(); o {
+	if v, ok := in.GetDnsDomainsOk(); ok {
 		networking["dns_domains"] = *v
 	}
-	if v, o := in.GetRoutesOk(); o {
+	if v, ok := in.GetRoutesOk(); ok {
 		routes := make([]map[string]interface{}, 0)
 		for _, r := range *v {
 			route := make(map[string]interface{})
-			if v, o := r.GetAddressOk(); o {
+			if v, ok := r.GetAddressOk(); ok {
 				route["address"] = *v
 			}
-			if v, o := r.GetNetmaskOk(); o {
+			if v, ok := r.GetNetmaskOk(); ok {
 				route["netmask"] = *v
 			}
-			if v, o := r.GetGatewayOk(); o {
+			if v, ok := r.GetGatewayOk(); ok {
 				route["gateway"] = *v
 			}
-			if v, o := r.GetNicOk(); o {
+			if v, ok := r.GetNicOk(); ok {
 				route["nic"] = *v
 			}
 			routes = append(routes, route)

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -1285,7 +1285,8 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
 
-					resource.TestCheckResourceAttr(resourceName, "controller.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.enabled", "false"),
 
 					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
@@ -1295,7 +1296,10 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
 
-					resource.TestCheckResourceAttr(resourceName, "log_server.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.0.retention_days", "30"),
+
 					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "445"),


### PR DESCRIPTION
resource appliance correctly read from remote. Before, it only compared to existing attributes in the statefile instead of comparing to remote.
the following attributes were affected by this

site
customization
ntp
ssh_server
snmp_server
healthcheck_server
prometheus_exporter
ping
log_server
controller
gateway
log_forwarder
connector

this fixes #144

<details>
acceptance test result for 5.4.1-25150-release

```bash
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/test_before_5.4
=== RUN   TestConfig/test_5.4_login
=== RUN   TestConfig/invalid_client_version
--- PASS: TestConfig (0.00s)
    --- PASS: TestConfig/test_before_5.4 (0.00s)
    --- PASS: TestConfig/test_5.4_login (0.00s)
    --- PASS: TestConfig/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.48s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.94s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (15.49s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.77s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.81s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.75s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.82s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (4.01s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.45s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.59s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccPolicyBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccLocalUserBasic (7.59s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.15s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccRingfenceRuleBasicTCP (8.44s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccRingfenceRuleBasicICMP (8.72s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccTrustedCertificateBasic (8.79s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccAdminMfaSettingsBasic (8.89s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccIPPoolBasic (9.05s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccGlobalSettingsBasic (9.25s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccPolicyBasic (9.28s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.45s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (9.70s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccRadiusIdentityProviderBasic (9.78s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccEntitlementBasicPing (9.88s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccLdapIdentityProviderBasic (10.25s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccMfaProviderBasic (7.59s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccEntitlementScriptBasic (7.71s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:264: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccDeviceScriptBasic (7.61s)
=== CONT  TestAccadministrativeRoleWithScope
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.10s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (16.43s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccCriteriaScriptBasic (7.79s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccBlacklistUserBasic (7.68s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccConditionBasic (8.00s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (16.83s)
--- PASS: TestAccEntitlementUpdateActionOrder (16.86s)
--- PASS: TestAccEntitlementBasicWithMonitor (16.89s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (8.31s)
--- PASS: TestAccApplianceConnector (8.14s)
--- PASS: TestAccApplianceBasicGateway (8.26s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (8.66s)
--- PASS: TestAccSiteBasic (19.10s)
--- PASS: TestAccApplianceCustomizationBasic (10.66s)
--- PASS: TestAccAppgateMfaProviderDataSource (4.53s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (5.30s)
--- PASS: TestAccadministrativeRoleBasic (5.09s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (4.69s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (5.00s)
--- PASS: TestAccadministrativeRoleWithScope (5.50s)
--- PASS: TestAccSamlIdentityProviderBasic (23.50s)
--- PASS: TestAccApplianceBasicController (16.27s)
--- PASS: TestAccAppliancePortalSetup (29.99s)
--- PASS: TestAccClientProfileBasic (45.16s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	108.214s

```


</details>






<details>
acceptance test result 5.3.2-23587-release




```bash
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/test_before_5.4
=== RUN   TestConfig/test_5.4_login
=== RUN   TestConfig/invalid_client_version
--- PASS: TestConfig (0.00s)
    --- PASS: TestConfig/test_before_5.4 (0.00s)
    --- PASS: TestConfig/test_5.4_login (0.00s)
    --- PASS: TestConfig/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (14.31s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.86s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (14.52s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.79s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.85s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.62s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.68s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.94s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.46s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.38s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccConditionBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccApplianceConnector
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2165: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.11s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (6.79s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccConditionBasic (7.77s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccBlacklistUserBasic (8.18s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccCriteriaScriptBasic (8.42s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccTrustedCertificateBasic (8.56s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccRingfenceRuleBasicICMP (8.62s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.93s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccEntitlementScriptBasic (8.94s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccApplianceBasicGateway (9.25s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccDeviceScriptBasic (9.26s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccLdapIdentityProviderBasic (9.37s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccRingfenceRuleBasicTCP (9.44s)
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:264: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.06s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicPing (10.03s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccApplianceConnector (10.10s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.14s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (9.35s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (10.51s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccGlobalSettingsBasic (8.06s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.66s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccAppgateMfaProviderDataSource (6.71s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (6.40s)
--- PASS: TestAccadministrativeRoleBasic (7.89s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.52s)
--- PASS: TestAccadministrativeRoleWithScope (8.34s)
--- PASS: TestAccMfaProviderBasic (7.52s)
--- PASS: TestAccAdminMfaSettingsBasic (7.62s)
--- PASS: TestAccIPPoolBasic (7.34s)
--- PASS: TestAccPolicyBasic (7.95s)
--- PASS: TestAccLocalUserBasic (7.62s)
--- PASS: TestAccSiteBasic (19.76s)
--- PASS: TestAccApplianceCustomizationBasic (11.60s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (12.60s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (12.31s)
--- PASS: TestAccApplianceBasicController (21.13s)
--- PASS: TestAccEntitlementUpdateActionOrder (12.94s)
--- PASS: TestAccEntitlementBasicWithMonitor (13.44s)
--- PASS: TestAccRadiusIdentityProviderBasic (6.08s)
--- PASS: TestAccSamlIdentityProviderBasic (17.17s)
--- PASS: TestAccClientProfileBasic (48.02s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	105.485s

```


</details>
