### PR TITLE
Profile DNS Name (used when exporting client profiles)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.6.2
+VERSION=0.6.3
 
 
 build:

--- a/appgate/resource_appgate_global_settings.go
+++ b/appgate/resource_appgate_global_settings.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -14,10 +15,10 @@ import (
 // https://discuss.hashicorp.com/t/singleton-resource/9869
 func resourceGlobalSettings() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGlobalSettingsCreate,
-		Read:   resourceGlobalSettingsRead,
-		Update: resourceGlobalSettingsUpdate,
-		Delete: resourceGlobalSettingsDelete,
+		CreateContext: resourceGlobalSettingsCreate,
+		ReadContext:   resourceGlobalSettingsRead,
+		UpdateContext: resourceGlobalSettingsUpdate,
+		DeleteContext: resourceGlobalSettingsDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -120,20 +121,24 @@ func resourceGlobalSettings() *schema.Resource {
 	}
 }
 
-func resourceGlobalSettingsCreate(d *schema.ResourceData, meta interface{}) error {
-	return resourceGlobalSettingsUpdate(d, meta)
+func resourceGlobalSettingsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
+	resourceGlobalSettingsUpdate(ctx, d, meta)
+	return diags
 }
 
-func resourceGlobalSettingsRead(d *schema.ResourceData, meta interface{}) error {
+func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Reading Global settings id: %+v", d.Id())
 	token := meta.(*Client).Token
 	api := meta.(*Client).API.GlobalSettingsApi
-	ctx := context.TODO()
 	request := api.GlobalSettingsGet(ctx)
 	settings, _, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
-		return fmt.Errorf("Failed to read Global settings, %+v", err)
+		return diag.FromErr(fmt.Errorf("Failed to read Global settings, %+v", err))
 	}
 	d.SetId(settings.GetCollectiveId())
 	d.Set("claims_token_expiration", settings.GetClaimsTokenExpiration())
@@ -154,18 +159,18 @@ func resourceGlobalSettingsRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("app_discovery_domains", settings.GetAppDiscoveryDomains())
 	d.Set("collective_id", settings.GetCollectiveId())
 
-	return nil
+	return diags
 }
 
-func resourceGlobalSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Updating Global settings")
 	token := meta.(*Client).Token
 	api := meta.(*Client).API.GlobalSettingsApi
-	ctx := context.TODO()
+
 	request := api.GlobalSettingsGet(ctx)
 	originalsettings, _, err := request.Authorization(token).Execute()
 	if err != nil {
-		return fmt.Errorf("Failed to read Global settings while updating, %+v", err)
+		return diag.FromErr(fmt.Errorf("Failed to read Global settings while updating, %+v", err))
 	}
 
 	if d.HasChange("claims_token_expiration") {
@@ -205,7 +210,7 @@ func resourceGlobalSettingsUpdate(d *schema.ResourceData, meta interface{}) erro
 		_, n := d.GetChange("app_discovery_domains")
 		domains, err := readArrayOfStringsFromConfig(n.(*schema.Set).List())
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 		originalsettings.SetAppDiscoveryDomains(domains)
 	}
@@ -213,13 +218,15 @@ func resourceGlobalSettingsUpdate(d *schema.ResourceData, meta interface{}) erro
 	req := api.GlobalSettingsPut(ctx)
 	_, err = req.GlobalSettings(originalsettings).Authorization(token).Execute()
 	if err != nil {
-		return fmt.Errorf("Could not update Global settings %+v", prettyPrintAPIError(err))
+		return diag.FromErr(fmt.Errorf("Could not update Global settings %+v", prettyPrintAPIError(err)))
 	}
 
-	return resourceGlobalSettingsRead(d, meta)
+	return resourceGlobalSettingsRead(ctx, d, meta)
 }
 
-func resourceGlobalSettingsDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceGlobalSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type
+	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Delete Global settings")
 	token := meta.(*Client).Token
 	api := meta.(*Client).API.GlobalSettingsApi
@@ -228,8 +235,8 @@ func resourceGlobalSettingsDelete(d *schema.ResourceData, meta interface{}) erro
 
 	_, err := request.Authorization(token).Execute()
 	if err != nil {
-		return fmt.Errorf("Could reset Global settings %+v", prettyPrintAPIError(err))
+		return diag.FromErr(fmt.Errorf("Could reset Global settings %+v", prettyPrintAPIError(err)))
 	}
 	d.SetId("")
-	return nil
+	return diags
 }

--- a/appgate/resource_appgate_global_settings_test.go
+++ b/appgate/resource_appgate_global_settings_test.go
@@ -83,3 +83,50 @@ func testAccGlobalSettingsImportStateCheckFunc(expectedStates int) resource.Impo
 		return nil
 	}
 }
+
+func TestAccGlobalSettings54ProfileHostname(t *testing.T) {
+	resourceName := "appgatesdp_global_settings.test_global_settings_profile_hostname"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					if currentVersion.LessThan(Appliance54Version) {
+						t.Skipf("Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using %s", currentVersion.String())
+					}
+				},
+				Config: testAccGlobalSettingsProfileHostname(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGlobalSettingsExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "administration_token_expiration"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_discovery_domains.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "audit_log_persistence_mode"),
+					resource.TestCheckResourceAttrSet(resourceName, "backup_api_enabled"),
+					resource.TestCheckResourceAttrSet(resourceName, "claims_token_expiration"),
+					resource.TestCheckResourceAttrSet(resourceName, "collective_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "entitlement_token_expiration"),
+					resource.TestCheckResourceAttrSet(resourceName, "fips"),
+					resource.TestCheckResourceAttrSet(resourceName, "geo_ip_updates"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpn_certificate_expiration"),
+					resource.TestCheckResourceAttr(resourceName, "profile_hostname", "xyz.appgate-sdp.com"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccGlobalSettingsImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccGlobalSettingsProfileHostname() string {
+	return `
+resource "appgatesdp_global_settings" "test_global_settings_profile_hostname" {
+	profile_hostname = "xyz.appgate-sdp.com"
+}
+`
+}

--- a/website/docs/r/global_settings.markdown
+++ b/website/docs/r/global_settings.markdown
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `audit_log_persistence_mode`: (Optional) Audit Log persistence mode.
 * `app_discovery_domains`: (Optional) Domains to monitor for for App Discovery feature.
 * `collective_id`: (Optional) A randomly generated ID during first installation to identify the Collective.
+* `profile_hostname`: (Optional) Client Connections, The hostname to use for generating profile URLs.
 
 
 ### app_discovery_domains


### PR DESCRIPTION
include profile dns name in global settings resource ( 5.4)

patches:
replaced old schema CRUD functions with context support.