### PR TITLE
Issue/147 - appliance.customization computed attribute.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.6.3
+VERSION=0.6.4
 
 
 build:

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -100,6 +100,7 @@ func resourceAppgateAppliance() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Customization assigned to this Appliance.",
 				Optional:    true,
+				Computed:    true,
 			},
 
 			"connect_to_peers_using_client_port_with_spa": {


### PR DESCRIPTION
This PR fixes https://github.com/appgate/terraform-provider-appgatesdp/issues/147

<details>

tested on 5.4.1-25150-release
```

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfig
=== RUN   TestConfig/test_before_5.4
=== RUN   TestConfig/test_5.4_login
=== RUN   TestConfig/invalid_client_version
--- PASS: TestConfig (0.01s)
    --- PASS: TestConfig/test_before_5.4 (0.00s)
    --- PASS: TestConfig/test_5.4_login (0.00s)
    --- PASS: TestConfig/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (8.09s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.64s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (14.53s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.66s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.62s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.64s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.58s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (4.10s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.55s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.19s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccApplianceConnector
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccSiteBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:264: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (2.10s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.15s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccAppgateMfaProviderDataSource (9.57s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (10.15s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (8.88s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (11.16s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccRingfenceRuleBasicTCP (11.23s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccMfaProviderBasic (11.45s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccTrustedCertificateBasic (11.69s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccadministrativeRoleWithScope (11.71s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccRingfenceRuleBasicICMP (11.72s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccadministrativeRoleBasic (11.98s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccApplianceBasicGateway (12.38s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (12.88s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccApplianceConnector (12.91s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccAdminMfaSettingsBasic (13.01s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccPolicyBasic (13.42s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccApplianceCustomizationBasic (18.22s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccEntitlementBasicPing (12.05s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccDeviceScriptBasic (11.18s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccEntitlementScriptBasic (11.81s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccBlacklistUserBasic (10.99s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccEntitlementBasicWithMonitor (22.62s)
--- PASS: TestAccCriteriaScriptBasic (11.85s)
--- PASS: TestAccConditionBasic (11.97s)
--- PASS: TestAccLocalUserBasic (10.78s)
--- PASS: TestAccIPPoolBasic (11.09s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (12.49s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (12.28s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (12.57s)
--- PASS: TestAccRadiusIdentityProviderBasic (12.00s)
--- PASS: TestAccLdapIdentityProviderBasic (11.64s)
--- PASS: TestAccSiteBasic (27.58s)
--- PASS: TestAccGlobalSettings54ProfileHostname (7.68s)
--- PASS: TestAccApplianceBasicController (28.19s)
--- PASS: TestAccGlobalSettingsBasic (7.67s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (12.93s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (11.23s)
--- PASS: TestAccEntitlementUpdateActionOrder (10.35s)
--- PASS: TestAccSamlIdentityProviderBasic (22.93s)
--- PASS: TestAccClientProfileBasic (38.85s)
--- PASS: TestAccAppliancePortalSetup (39.45s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	101.769s
```


</details>