### PR TITLE
Configure provider with config_file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.6.5
+VERSION=0.6.6
 
 
 build:

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -40,6 +40,17 @@ type Client struct {
 	LatestSupportedVersion *version.Version
 	ClientVersion          int
 	API                    *openapi.APIClient
+	Config                 *Config
+}
+
+// AppgateConfigFile used with  "config_path"
+type AppgateConfigFile struct {
+	URL           string `json:"appgate_url"`
+	Username      string `json:"appgate_username"`
+	Password      string `json:"appgate_password"`
+	Provider      string `json:"appgate_provider"`
+	ClientVersion int    `json:"appgate_client_version"`
+	Insecure      bool   `json:"appgate_insecure"`
 }
 
 // Client creates
@@ -77,26 +88,10 @@ func (c *Config) Client() (*Client, error) {
 		return nil, errors.New("failed to initialize api client")
 	}
 
-	response, err := login(apiClient, c)
-	if err != nil {
-		return nil, err
-	}
-
-	latestSupportedVersion, err := version.NewVersion(ApplianceVersionMap[DefaultClientVersion])
-	if err != nil {
-		return nil, err
-	}
-
-	currentVersion, err := guessVersion(response, c.Version)
-	if err != nil {
-		return nil, err
-	}
 	client := &Client{
-		API:                    apiClient,
-		Token:                  fmt.Sprintf("Bearer %s", *openapi.PtrString(*response.Token)),
-		ApplianceVersion:       currentVersion,
-		ClientVersion:          c.Version,
-		LatestSupportedVersion: latestSupportedVersion,
+		API:           apiClient,
+		ClientVersion: c.Version,
+		Config:        c,
 	}
 
 	return client, nil
@@ -120,16 +115,40 @@ func guessVersion(response *openapi.LoginResponse, clientVersion int) (*version.
 	return nil, fmt.Errorf("could not determine appliance version with client version %d", clientVersion)
 }
 
-func login(apiClient *openapi.APIClient, cfg *Config) (*openapi.LoginResponse, error) {
+// GetToken makes first login and initiate the client towards the controller.
+// this is always the first made
+func (c *Client) GetToken() (string, error) {
+	cfg := c.Config
+	response, err := c.login()
+	if err != nil {
+		return "", err
+	}
+	latestSupportedVersion, err := version.NewVersion(ApplianceVersionMap[DefaultClientVersion])
+	if err != nil {
+		return "", err
+	}
+
+	currentVersion, err := guessVersion(response, cfg.Version)
+	if err != nil {
+		return "", err
+	}
+	c.ApplianceVersion = currentVersion
+	c.LatestSupportedVersion = latestSupportedVersion
+	token := fmt.Sprintf("Bearer %s", *openapi.PtrString(*response.Token))
+
+	return token, nil
+}
+
+func (c *Client) login() (*openapi.LoginResponse, error) {
 	ctx := context.Background()
 	loginOpts := openapi.LoginRequest{
-		ProviderName: cfg.Provider,
-		Username:     openapi.PtrString(cfg.Username),
-		Password:     openapi.PtrString(cfg.Password),
+		ProviderName: c.Config.Provider,
+		Username:     openapi.PtrString(c.Config.Username),
+		Password:     openapi.PtrString(c.Config.Password),
 		DeviceId:     uuid.New().String(),
 	}
 
-	loginResponse, _, err := apiClient.LoginApi.LoginPost(ctx).LoginRequest(loginOpts).Execute()
+	loginResponse, _, err := c.API.LoginApi.LoginPost(ctx).LoginRequest(loginOpts).Execute()
 	if err != nil {
 		return nil, prettyPrintAPIError(err)
 	}

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -22,14 +22,14 @@ const (
 
 // Config for appgate provider.
 type Config struct {
-	URL      string
-	Username string
-	Password string
-	Provider string
-	Insecure bool
-	Timeout  int
-	Debug    bool
-	Version  int
+	URL      string `json:"appgate_url,omitempty"`
+	Username string `json:"appgate_username,omitempty"`
+	Password string `json:"appgate_password,omitempty"`
+	Provider string `json:"appgate_provider,omitempty"`
+	Insecure bool   `json:"appgate_insecure,omitempty"`
+	Timeout  int    `json:"appgate_timeout,omitempty"`
+	Debug    bool   `json:"appgate_http_debug,omitempty"`
+	Version  int    `json:"appgate_client_version,omitempty"`
 }
 
 // Client is the appgate API client.
@@ -41,16 +41,6 @@ type Client struct {
 	ClientVersion          int
 	API                    *openapi.APIClient
 	Config                 *Config
-}
-
-// AppgateConfigFile used with  "config_path"
-type AppgateConfigFile struct {
-	URL           string `json:"appgate_url,omitempty"`
-	Username      string `json:"appgate_username,omitempty"`
-	Password      string `json:"appgate_password,omitempty"`
-	Provider      string `json:"appgate_provider,omitempty"`
-	ClientVersion int    `json:"appgate_client_version,omitempty"`
-	Insecure      bool   `json:"appgate_insecure,omitempty"`
 }
 
 // Client creates

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -45,12 +45,12 @@ type Client struct {
 
 // AppgateConfigFile used with  "config_path"
 type AppgateConfigFile struct {
-	URL           string `json:"appgate_url"`
-	Username      string `json:"appgate_username"`
-	Password      string `json:"appgate_password"`
-	Provider      string `json:"appgate_provider"`
-	ClientVersion int    `json:"appgate_client_version"`
-	Insecure      bool   `json:"appgate_insecure"`
+	URL           string `json:"appgate_url,omitempty"`
+	Username      string `json:"appgate_username,omitempty"`
+	Password      string `json:"appgate_password,omitempty"`
+	Provider      string `json:"appgate_provider,omitempty"`
+	ClientVersion int    `json:"appgate_client_version,omitempty"`
+	Insecure      bool   `json:"appgate_insecure,omitempty"`
 }
 
 // Client creates
@@ -118,11 +118,15 @@ func guessVersion(response *openapi.LoginResponse, clientVersion int) (*version.
 // GetToken makes first login and initiate the client towards the controller.
 // this is always the first made
 func (c *Client) GetToken() (string, error) {
+	if len(c.Token) > 0 {
+		return c.Token, nil
+	}
 	cfg := c.Config
 	response, err := c.login()
 	if err != nil {
 		return "", err
 	}
+
 	latestSupportedVersion, err := version.NewVersion(ApplianceVersionMap[DefaultClientVersion])
 	if err != nil {
 		return "", err
@@ -134,9 +138,9 @@ func (c *Client) GetToken() (string, error) {
 	}
 	c.ApplianceVersion = currentVersion
 	c.LatestSupportedVersion = latestSupportedVersion
-	token := fmt.Sprintf("Bearer %s", *openapi.PtrString(*response.Token))
+	c.Token = fmt.Sprintf("Bearer %s", *openapi.PtrString(*response.Token))
 
-	return token, nil
+	return c.Token, nil
 }
 
 func (c *Client) login() (*openapi.LoginResponse, error) {

--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -152,7 +152,7 @@ var (
 `
 )
 
-func TestConfig(t *testing.T) {
+func TestConfigGetToken(t *testing.T) {
 
 	type fields struct {
 		ResponseBody string
@@ -210,11 +210,19 @@ func TestConfig(t *testing.T) {
 				Version:  tt.clientVersion,
 			}
 			appgateClient, err := c.Client()
+			if err != nil {
+				t.Errorf("Got err, expected None %s", err)
+				return
+			}
+			if appgateClient == nil {
+				return
+			}
+			token, err := appgateClient.GetToken()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Config.Client() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if appgateClient == nil && tt.wantErr {
+			if tt.wantErr && (err != nil) {
 				return
 			}
 
@@ -229,7 +237,7 @@ func TestConfig(t *testing.T) {
 			if !appgateClient.LatestSupportedVersion.Equal(latestSupportedVersion) {
 				t.Fatalf("Expected Latest Version%s, got %s", tt.expectedVersion, appgateClient.ApplianceVersion)
 			}
-			if appgateClient.Token != "Bearer very-long-string" {
+			if token != "Bearer very-long-string" {
 				t.Fatalf("Expected token Bearer very-long-string, got %s", appgateClient.Token)
 			}
 		})

--- a/appgate/data_source_appgate_administrative_role.go
+++ b/appgate/data_source_appgate_administrative_role.go
@@ -31,7 +31,10 @@ func dataSourceAppgateAdministrativeRole() *schema.Resource {
 
 func dataSourceAppgateAdministrativeRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Data source Administrative role")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.AdministrativeRolesApi
 
 	adminID, iok := d.GetOk("administrative_role_id")

--- a/appgate/data_source_appgate_appliance.go
+++ b/appgate/data_source_appgate_appliance.go
@@ -29,7 +29,10 @@ func dataSourceAppgateAppliance() *schema.Resource {
 
 func dataSourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source Appliance")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 
 	applianceID, iok := d.GetOk("appliance_id")

--- a/appgate/data_source_appgate_appliance_customization.go
+++ b/appgate/data_source_appgate_appliance_customization.go
@@ -30,7 +30,10 @@ func dataSourceAppgateApplianceCustomization() *schema.Resource {
 
 func dataSourceAppgateApplianceCustomizationRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source Appliance customization")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 
 	applianceID, iok := d.GetOk("appliance_customization_id")

--- a/appgate/data_source_appgate_appliance_seed.go
+++ b/appgate/data_source_appgate_appliance_seed.go
@@ -49,7 +49,10 @@ func dataSourceAppgateApplianceSeed() *schema.Resource {
 }
 
 func dataSourceAppgateApplianceSeedRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 	ctx := context.TODO()
 	applianceID, iok := d.GetOk("appliance_id")

--- a/appgate/data_source_appgate_condition.go
+++ b/appgate/data_source_appgate_condition.go
@@ -28,7 +28,10 @@ func dataSourceAppgateCondition() *schema.Resource {
 }
 
 func dataSourceAppgateConditionRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConditionsApi
 
 	conditionID, iok := d.GetOk("condition_id")

--- a/appgate/data_source_appgate_criteria_script.go
+++ b/appgate/data_source_appgate_criteria_script.go
@@ -28,7 +28,10 @@ func dataSourceCriteriaScript() *schema.Resource {
 }
 
 func dataSourceAppgateCriteriaScriptRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.CriteriaScriptsApi
 
 	criteraScriptID, iok := d.GetOk("criteria_script_id")

--- a/appgate/data_source_appgate_device_script.go
+++ b/appgate/data_source_appgate_device_script.go
@@ -28,7 +28,10 @@ func dataSourceDeviceScript() *schema.Resource {
 }
 
 func dataSourceAppgateDeviceScriptRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 
 	deviceScriptID, iok := d.GetOk("device_script_id")

--- a/appgate/data_source_appgate_entitlement.go
+++ b/appgate/data_source_appgate_entitlement.go
@@ -31,7 +31,10 @@ func dataSourceAppgateEntitlement() *schema.Resource {
 func dataSourceAppgateEntitlementRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.EntitlementsApi
 
 	entitlementID, iok := d.GetOk("entitlement_id")

--- a/appgate/data_source_appgate_entitlement_script.go
+++ b/appgate/data_source_appgate_entitlement_script.go
@@ -28,7 +28,10 @@ func dataSourceEntitlementScript() *schema.Resource {
 }
 
 func dataSourceAppgateEntitlementScriptRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.EntitlementScriptsApi
 
 	entitlementScriptID, iok := d.GetOk("entitlement_script_id")

--- a/appgate/data_source_appgate_global_settings.go
+++ b/appgate/data_source_appgate_global_settings.go
@@ -84,7 +84,10 @@ func dataSourceGlobalSettings() *schema.Resource {
 }
 
 func dataSourceAppgateGlobalSettingsRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.GlobalSettingsApi
 
 	settings, err := getGlobalSettings(api, token)

--- a/appgate/data_source_appgate_identity_provider.go
+++ b/appgate/data_source_appgate_identity_provider.go
@@ -30,7 +30,10 @@ func dataSourceAppgateIdentityProvider() *schema.Resource {
 
 func dataSourceAppgateIdentityProviderRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source identity provider")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IdentityProvidersApi
 
 	providerID, iok := d.GetOk("identity_provider_id")

--- a/appgate/data_source_appgate_ip_pool.go
+++ b/appgate/data_source_appgate_ip_pool.go
@@ -28,7 +28,10 @@ func dataSourceAppgateIPPool() *schema.Resource {
 }
 
 func dataSourceAppgateIPPoolRead(d *schema.ResourceData, meta interface{}) error {
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IPPoolsApi
 
 	ippoolID, iok := d.GetOk("ip_pool_id")

--- a/appgate/data_source_appgate_local_user.go
+++ b/appgate/data_source_appgate_local_user.go
@@ -30,7 +30,10 @@ func dataSourceAppgateLocalUser() *schema.Resource {
 
 func dataSourceAppgateLocalUserRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source local user")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalUsersApi
 
 	userID, iok := d.GetOk("local_user_id")

--- a/appgate/data_source_appgate_mfa_provider.go
+++ b/appgate/data_source_appgate_mfa_provider.go
@@ -30,7 +30,10 @@ func dataSourceAppgateMfaProvider() *schema.Resource {
 
 func dataSourceAppgateMfaProviderRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source MFA provider")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAProvidersApi
 
 	providerID, iok := d.GetOk("mfa_provider_id")

--- a/appgate/data_source_appgate_policy.go
+++ b/appgate/data_source_appgate_policy.go
@@ -38,7 +38,10 @@ func dataSourceAppgatePolicy() *schema.Resource {
 
 func dataSourceAppgatePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source policy")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.PoliciesApi
 	ctx := context.Background()
 

--- a/appgate/data_source_appgate_ringfence_rule.go
+++ b/appgate/data_source_appgate_ringfence_rule.go
@@ -38,7 +38,10 @@ func dataSourceAppgateRingfenceRule() *schema.Resource {
 
 func dataSourceAppgateRingfenceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source Ringfence Rules")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RingfenceRulesApi
 	ctx := context.Background()
 	ringfenceID, iok := d.GetOk("ringfence_rule_id")

--- a/appgate/data_source_appgate_site.go
+++ b/appgate/data_source_appgate_site.go
@@ -56,7 +56,10 @@ func dataSourceAppgateSite() *schema.Resource {
 
 func dataSourceAppgateSiteRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source Site")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.SitesApi
 
 	siteID, iok := d.GetOk("site_id")

--- a/appgate/data_source_appgate_trusted_certificate.go
+++ b/appgate/data_source_appgate_trusted_certificate.go
@@ -30,7 +30,10 @@ func dataSourceAppgateTrustedCertificate() *schema.Resource {
 
 func dataSourceAppgateTrustedCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Data source trusted certificate")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.TrustedCertificatesApi
 
 	trustedCertID, iok := d.GetOk("trusted_certificate_id")

--- a/appgate/identity_provider.go
+++ b/appgate/identity_provider.go
@@ -471,13 +471,13 @@ func readIdentityProviderOnDemandClaimMappingFromConfig(input []interface{}) []m
 
 func identityProviderDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete LdapProvider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IdentityProvidersApi
 
-	request := api.IdentityProvidersIdDelete(context.Background(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.IdentityProvidersIdDelete(context.Background(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete LdapProvider %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -81,7 +81,6 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CONFIG_PATH", nil),
 				Description: "Path to the appgate config file. Can be set with APPGATE_CONFIG_PATH.",
-				// ConflictsWith: []string{"url"},
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -177,7 +176,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			return nil, diags
 		}
 		defer file.Close()
-		configFile := AppgateConfigFile{}
+		configFile := Config{}
 		if err := json.NewDecoder(file).Decode(&configFile); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
@@ -186,23 +185,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			})
 			return nil, diags
 		}
-		if len(configFile.URL) > 0 {
-			config.URL = configFile.URL
-		}
-		if len(config.Username) > 0 {
-			config.Username = configFile.Username
-		}
-		if len(config.Password) > 0 {
-			config.Password = configFile.Password
-		}
-		if len(config.Provider) > 0 {
-			config.Provider = configFile.Provider
-		}
-		if config.Version > 0 {
-			config.Version = configFile.ClientVersion
-		}
-		config.Insecure = configFile.Insecure
-
+		config = configFile
 	} else if !requiredParameters(d) {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -236,7 +219,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if v, ok := d.GetOk("client_version"); ok {
 		config.Version = v.(int)
 	}
-
 	c, err := config.Client()
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -2,8 +2,10 @@ package appgate
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
-	"log"
+	"os"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -73,6 +75,13 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CLIENT_VERSION", DefaultClientVersion),
+			},
+			"config_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CONFIG_PATH", nil),
+				Description: "Path to the appgate config file. Can be set with APPGATE_CONFIG_PATH.",
+				// ConflictsWith: []string{"url"},
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -146,8 +155,44 @@ func requiredParameters(d *schema.ResourceData) bool {
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
+	config := Config{}
+	config.Timeout = 20
 
-	if !requiredParameters(d) {
+	if path, ok := d.GetOkExists("config_path"); ok {
+		p := path.(string)
+		file, err := os.OpenFile(p, os.O_RDWR, 0644)
+		if errors.Is(err, os.ErrNotExist) {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Missing Appgate SDP credentials",
+				Detail:   fmt.Sprintf("appgate config_path file not found %s", err),
+			})
+			return nil, diags
+		} else if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Missing Appgate SDP credentials",
+				Detail:   err.Error(),
+			})
+			return nil, diags
+		}
+		defer file.Close()
+		configFile := AppgateConfigFile{}
+		if err := json.NewDecoder(file).Decode(&configFile); err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  "Missing Appgate SDP credentials",
+				Detail:   fmt.Sprintf("appgate config_path invalid json format %s", err),
+			})
+			return nil, diags
+		}
+		config.URL = configFile.URL
+		config.Username = configFile.Username
+		config.Password = configFile.Password
+		config.Provider = configFile.Provider
+		config.Version = configFile.ClientVersion
+		config.Insecure = configFile.Insecure
+	} else if !requiredParameters(d) {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Missing Appgate SDP credentials",
@@ -155,25 +200,36 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		})
 		return nil, diags
 	}
-	username := d.Get("username").(string)
-	password := d.Get("password").(string)
-	url := d.Get("url").(string)
-	v := d.Get("client_version").(int)
-	config := Config{
-		URL:      url,
-		Username: username,
-		Password: password,
-		Provider: d.Get("provider").(string),
-		Insecure: d.Get("insecure").(bool),
-		Timeout:  20,
-		Debug:    d.Get("debug").(bool),
-		Version:  v,
+	// overwrite config file value with ENV Variables or set attributes in the provider block
+	if v, ok := d.GetOk("username"); ok {
+		config.Username = v.(string)
+	}
+	if v, ok := d.GetOk("password"); ok {
+		config.Password = v.(string)
+	}
+	if v, ok := d.GetOk("url"); ok {
+		config.URL = v.(string)
+	}
+	if v, ok := d.GetOk("provider"); ok {
+		config.Provider = v.(string)
+	}
+	if v, ok := d.GetOk("Insecure"); ok {
+		config.Insecure = v.(bool)
+	}
+	if v, ok := d.GetOk("provider"); ok {
+		config.Provider = v.(string)
+	}
+	if v, ok := d.GetOk("debug"); ok {
+		config.Debug = v.(bool)
+	}
+	if v, ok := d.GetOk("client_version"); ok {
+		config.Version = v.(int)
 	}
 	c, err := config.Client()
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Unable to create Appgate SDP SDK client v%d", v),
+			Summary:  fmt.Sprintf("Unable to create Appgate SDP SDK client v%d", config.Version),
 			Detail:   fmt.Sprintf("Unable to authenticate user for authenticated Appgate SDP client %s", err),
 		})
 
@@ -182,18 +238,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if c == nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("Unable to create Appgate SDP SDK client v%d", v),
+			Summary:  fmt.Sprintf("Unable to create Appgate SDP SDK client v%d", config.Version),
 			Detail:   "Appgate sdp client is nil, internal error",
 		})
 		return nil, diags
 	}
-	if c.ApplianceVersion.LessThan(c.LatestSupportedVersion) {
-		diags = append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
-			Summary:  fmt.Sprintf("You are using old version of Appgate SDP SDK client v%d", v),
-			Detail:   "You are using an outdated version of appgate appliances, you should consider updating to the latest version.",
-		})
-	}
-	log.Printf("[INFO] Appgate SDP Appliance Version %q client version v%d", c.ApplianceVersion, c.ClientVersion)
+
 	return c, diags
 }

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -186,12 +186,23 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			})
 			return nil, diags
 		}
-		config.URL = configFile.URL
-		config.Username = configFile.Username
-		config.Password = configFile.Password
-		config.Provider = configFile.Provider
-		config.Version = configFile.ClientVersion
+		if len(configFile.URL) > 0 {
+			config.URL = configFile.URL
+		}
+		if len(config.Username) > 0 {
+			config.Username = configFile.Username
+		}
+		if len(config.Password) > 0 {
+			config.Password = configFile.Password
+		}
+		if len(config.Provider) > 0 {
+			config.Provider = configFile.Provider
+		}
+		if config.Version > 0 {
+			config.Version = configFile.ClientVersion
+		}
 		config.Insecure = configFile.Insecure
+
 	} else if !requiredParameters(d) {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
@@ -213,7 +224,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if v, ok := d.GetOk("provider"); ok {
 		config.Provider = v.(string)
 	}
-	if v, ok := d.GetOk("Insecure"); ok {
+	if v, ok := d.GetOk("insecure"); ok {
 		config.Insecure = v.(bool)
 	}
 	if v, ok := d.GetOk("provider"); ok {
@@ -225,6 +236,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	if v, ok := d.GetOk("client_version"); ok {
 		config.Version = v.(int)
 	}
+
 	c, err := config.Client()
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{

--- a/appgate/provider_test.go
+++ b/appgate/provider_test.go
@@ -65,15 +65,22 @@ func TestProvider_impl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("APPGATE_ADDRESS"); v == "" {
-		t.Fatal("APPGATE_ADDRESS must be set for acceptance tests")
+	if v := os.Getenv("APPGATE_CONFIG_PATH"); v != "" {
+		if _, err := os.Stat(v); os.IsNotExist(err) {
+			t.Fatal("APPGATE_CONFIG_PATH is set, but file not found")
+		}
+	} else {
+		if v := os.Getenv("APPGATE_ADDRESS"); v == "" {
+			t.Fatal("APPGATE_ADDRESS must be set for acceptance tests")
+		}
+		if v := os.Getenv("APPGATE_USERNAME"); v == "" {
+			t.Fatal("APPGATE_USERNAME must be set for acceptance tests")
+		}
+		if v := os.Getenv("APPGATE_PASSWORD"); v == "" {
+			t.Fatal("APPGATE_PASSWORD must be set for acceptance tests")
+		}
 	}
-	if v := os.Getenv("APPGATE_USERNAME"); v == "" {
-		t.Fatal("APPGATE_USERNAME must be set for acceptance tests")
-	}
-	if v := os.Getenv("APPGATE_PASSWORD"); v == "" {
-		t.Fatal("APPGATE_PASSWORD must be set for acceptance tests")
-	}
+
 	err := testAccProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(nil))
 	if err != nil {
 		t.Fatalf("err: %v", err)

--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -136,7 +136,10 @@ func resourceAppgateAdministrativeRoleCreate(ctx context.Context, d *schema.Reso
 	var diags diag.Diagnostics
 
 	log.Printf("[DEBUG] Creating Administrative role: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.AdministrativeRolesApi
 	args := openapi.NewAdministrativeRoleWithDefaults()
 	args.Id = uuid.New().String()
@@ -235,7 +238,10 @@ func resourceAppgateAdministrativeRoleRead(ctx context.Context, d *schema.Resour
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Reading Administrative role id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.AdministrativeRolesApi
 	request := api.AdministrativeRolesIdGet(ctx, d.Id())
 	administrativeRole, _, err := request.Authorization(token).Execute()
@@ -304,7 +310,10 @@ func flattenAdministrativeRolePrivilegesScope(scope openapi.AdministrativePrivil
 
 func resourceAppgateAdministrativeRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Updating Administrative role: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.AdministrativeRolesApi
 	request := api.AdministrativeRolesIdGet(ctx, d.Id())
 	originalAdministrativeRole, _, err := request.Authorization(token).Execute()
@@ -345,13 +354,12 @@ func resourceAppgateAdministrativeRoleDelete(ctx context.Context, d *schema.Reso
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Delete Administrative role: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
-	api := meta.(*Client).API.AdministrativeRolesApi
-
-	request := api.AdministrativeRolesIdDelete(ctx, d.Id())
-
-	_, err := request.Authorization(token).Execute()
+	token, err := meta.(*Client).GetToken()
 	if err != nil {
+		return diag.FromErr(err)
+	}
+	api := meta.(*Client).API.AdministrativeRolesApi
+	if _, err := api.AdministrativeRolesIdDelete(ctx, d.Id()).Authorization(token).Execute(); err != nil {
 		return diag.FromErr(fmt.Errorf("Could not delete Administrative role %+v", prettyPrintAPIError(err)))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_administrative_role_test.go
+++ b/appgate/resource_appgate_administrative_role_test.go
@@ -145,7 +145,10 @@ func TestAccadministrativeRoleWithScope(t *testing.T) {
 
 func testAccCheckadministrativeRoleExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.AdministrativeRolesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -157,8 +160,7 @@ func testAccCheckadministrativeRoleExists(resource string) resource.TestCheckFun
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.AdministrativeRolesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.AdministrativeRolesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching Administrative Role with resource %s. %s", resource, err)
 		}
 		return nil
@@ -171,11 +173,13 @@ func testAccCheckadministrativeRoleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.AdministrativeRolesApi
 
-		_, _, err := api.AdministrativeRolesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.AdministrativeRolesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Administrative Role still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_administrative_role_test.go
+++ b/appgate/resource_appgate_administrative_role_test.go
@@ -205,7 +205,9 @@ func TestAccadministrativeMultiplePrivilegesValidation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
 					if currentVersion.LessThan(Appliance53Version) {
 						t.Skip("Test only for 5.3 and above, privileges.target RegisteredDevice not supported prior to 5.3")
 					}
@@ -259,7 +261,9 @@ func TestAccadministrativeMultiplePrivilegesValidation52(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
 					if currentVersion.GreaterThanOrEqual(Appliance53Version) {
 						t.Skip("Test is only for 5.2, privileges.target OnBoardedDevice")
 					}
@@ -303,20 +307,20 @@ func testAccCheckadministrativeRoleMultiplePrivlegesConfig(context map[string]in
 resource "appgatesdp_administrative_role" "test_administrative_role_129" {
 	name  = "%{name}"
 	tags  = ["aa", "bb", "cc"]
-	
+
 	privileges {
 		type   = "View"
 		target = "%{target}"
-	
+
 		scope {
 		all = true
 		}
 	}
-	
+
 	privileges {
 		type   = "Delete"
 		target = "%{target}"
-	
+
 		scope {
 		all = true
 		}

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -1068,7 +1068,10 @@ func resourceAppgateAppliance() *schema.Resource {
 func resourceAppgateApplianceCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Appliance with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	args := openapi.NewApplianceWithDefaults()
@@ -1459,7 +1462,10 @@ func readNetworkHostFromConfig(hosts []interface{}) ([]openapi.ApplianceAllOfNet
 
 func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Appliance Name: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	ctx := context.Background()
@@ -2101,7 +2107,10 @@ func flattenApplianceNetworking(in openapi.ApplianceAllOfNetworking) ([]map[stri
 func resourceAppgateApplianceUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Appliance: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.AppliancesIdGet(ctx, d.Id())
@@ -2311,7 +2320,10 @@ func resourceAppgateApplianceUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAppgateApplianceDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Appliance: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.AppliancesApi
 	ctx := context.Background()
 

--- a/appgate/resource_appgate_appliance_customization.go
+++ b/appgate/resource_appgate_appliance_customization.go
@@ -111,7 +111,10 @@ func resourceAppgateApplianceCustomizations() *schema.Resource {
 
 func resourceAppgateApplianceCustomizationCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Appliance customization: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 	args := openapi.NewApplianceCustomizationWithDefaults()
 	args.Id = uuid.New().String()
@@ -145,7 +148,10 @@ func resourceAppgateApplianceCustomizationCreate(d *schema.ResourceData, meta in
 
 func resourceAppgateApplianceCustomizationRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Appliance customization id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 	ctx := context.TODO()
 	request := api.ApplianceCustomizationsIdGet(ctx, d.Id())
@@ -180,7 +186,10 @@ func resourceAppgateApplianceCustomizationRead(d *schema.ResourceData, meta inte
 
 func resourceAppgateApplianceCustomizationUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Appliance customization: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 	ctx := context.TODO()
 	request := api.ApplianceCustomizationsIdGet(ctx, d.Id())
@@ -233,13 +242,13 @@ func resourceAppgateApplianceCustomizationUpdate(d *schema.ResourceData, meta in
 
 func resourceAppgateApplianceCustomizationDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Appliance customization id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 
-	request := api.ApplianceCustomizationsIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.ApplianceCustomizationsIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Appliance customization %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_appliance_customization_test.go
+++ b/appgate/resource_appgate_appliance_customization_test.go
@@ -113,7 +113,10 @@ resource "appgatesdp_appliance_customization" "test_acc_appliance_customization"
 
 func testAccCheckApplianceCustomizationExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ApplianceCustomizationsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -125,8 +128,7 @@ func testAccCheckApplianceCustomizationExists(resource string) resource.TestChec
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.ApplianceCustomizationsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.ApplianceCustomizationsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching appliance customization with resource %s. %s", resource, err)
 		}
 		return nil
@@ -139,11 +141,13 @@ func testAccCheckApplianceCustomizationDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ApplianceCustomizationsApi
 
-		_, _, err := api.ApplianceCustomizationsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.ApplianceCustomizationsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Appliance customization still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -2160,7 +2160,9 @@ func TestAccAppliancePortalSetup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
 					if currentVersion.LessThan(Appliance54Version) {
 						t.Skip("Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.")
 					}

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -523,11 +523,13 @@ func testAccCheckApplianceDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.AppliancesApi
 
-		_, _, err := api.AppliancesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.AppliancesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Appliance still exists, %+v", err)
 		}
 	}
@@ -1244,7 +1246,10 @@ resource "appgatesdp_appliance" "connector" {
 
 func testAccCheckApplianceExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.AppliancesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -1256,8 +1261,7 @@ func testAccCheckApplianceExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.AppliancesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.AppliancesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching appliance with resource %s. %s", resource, err)
 		}
 		return nil

--- a/appgate/resource_appgate_blacklist_user.go
+++ b/appgate/resource_appgate_blacklist_user.go
@@ -50,7 +50,10 @@ func resourceAppgateBlacklistUser() *schema.Resource {
 
 func resourceAppgateBlacklistUserCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating blacklisted user")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.BlacklistedUsersApi
 	args := openapi.NewBlacklistEntryWithDefaults()
 
@@ -96,7 +99,10 @@ func queryEntry(ctx context.Context, api *openapi.BlacklistedUsersApiService, to
 
 func resourceAppgateBlacklistUserRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading blacklisted user id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.BlacklistedUsersApi
 	entry, err := queryEntry(context.TODO(), api, token, d.Id())
 	if err != nil {
@@ -112,13 +118,13 @@ func resourceAppgateBlacklistUserRead(d *schema.ResourceData, meta interface{}) 
 
 func resourceAppgateBlacklistUserDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading blacklisted user id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.BlacklistedUsersApi
 
-	request := api.BlacklistDistinguishedNameDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.BlacklistDistinguishedNameDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete blacklisted user %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_client_connections.go
+++ b/appgate/resource_appgate_client_connections.go
@@ -77,7 +77,10 @@ func resourceClientConnectionsCreate(d *schema.ResourceData, meta interface{}) e
 
 func resourceClientConnectionsRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Client Connections id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ClientConnectionsApi
 	ctx := context.TODO()
 	request := api.ClientConnectionsGet(ctx)
@@ -115,7 +118,10 @@ func resourceClientConnectionsRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceClientConnectionsUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Client Connections")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ClientConnectionsApi
 	ctx := context.TODO()
 	request := api.ClientConnectionsGet(ctx)
@@ -171,13 +177,13 @@ func readClientConnectionProfilesFromConfig(input []interface{}) []openapi.Clien
 
 func resourceClientConnectionsDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete/Resetting Client Connections")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ClientConnectionsApi
 
-	request := api.ClientConnectionsDelete(context.TODO())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.ClientConnectionsDelete(context.Background()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could reset Client Connections %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_client_connections_test.go
+++ b/appgate/resource_appgate_client_connections_test.go
@@ -53,7 +53,10 @@ func testAccCheckClientConnectionsBasic() string {
 
 func testAccCheckClientConnectionsExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ClientConnectionsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -65,8 +68,7 @@ func testAccCheckClientConnectionsExists(resource string) resource.TestCheckFunc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.ClientConnectionsGet(context.Background()).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.ClientConnectionsGet(context.Background()).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching ClientConnections with resource %s. %s", resource, err)
 		}
 		return nil

--- a/appgate/resource_appgate_client_profile.go
+++ b/appgate/resource_appgate_client_profile.go
@@ -67,7 +67,7 @@ func getIdFromProfile(profile openapi.ClientConnectionsProfiles) string {
 func resourceAppgateClientProfileCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Create Client Profile %s", d.Get("name"))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+
 	api := meta.(*Client).API.ClientConnectionsApi
 
 	err := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
@@ -77,6 +77,10 @@ func resourceAppgateClientProfileCreate(d *schema.ResourceData, meta interface{}
 		time.Sleep(time.Duration(duration) * time.Second)
 		if err := applianceStatsRetryable(ctx, meta); err != nil {
 			return err
+		}
+		token, err := meta.(*Client).GetToken()
+		if err != nil {
+			return resource.RetryableError(err)
 		}
 		clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
 		if err != nil {
@@ -116,7 +120,10 @@ func resourceAppgateClientProfileCreate(d *schema.ResourceData, meta interface{}
 
 func resourceAppgateClientProfileRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Client Profile id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ClientConnectionsApi
 	ctx := context.Background()
 	clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
@@ -144,7 +151,10 @@ func resourceAppgateClientProfileRead(d *schema.ResourceData, meta interface{}) 
 func resourceAppgateClientProfileUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Client Profile %+v", d.Id())
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ClientConnectionsApi
 	clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
 	if err != nil {
@@ -181,7 +191,6 @@ func resourceAppgateClientProfileUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAppgateClientProfileDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete client profile %+v", d.Id())
-	token := meta.(*Client).Token
 	ctx := context.Background()
 	api := meta.(*Client).API.ClientConnectionsApi
 
@@ -192,6 +201,10 @@ func resourceAppgateClientProfileDelete(d *schema.ResourceData, meta interface{}
 		time.Sleep(time.Duration(duration) * time.Second)
 		if err := applianceStatsRetryable(ctx, meta); err != nil {
 			return err
+		}
+		token, err := meta.(*Client).GetToken()
+		if err != nil {
+			return resource.RetryableError(err)
 		}
 		clientConnections, _, err := api.ClientConnectionsGet(ctx).Authorization(token).Execute()
 		if err != nil {

--- a/appgate/resource_appgate_client_profile_test.go
+++ b/appgate/resource_appgate_client_profile_test.go
@@ -47,7 +47,10 @@ resource "appgatesdp_client_profile" "test_client_profile" {
 
 func testAccCheckClientProfileExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ClientConnectionsApi
 
 		rs, ok := state.RootModule().Resources[resource]

--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -130,7 +130,10 @@ func resourceAppgateCondition() *schema.Resource {
 func resourceAppgateConditionCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Condition with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConditionsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 
@@ -185,7 +188,10 @@ func resourceAppgateConditionCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAppgateConditionRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Condition Name: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConditionsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	ctx := context.Background()
@@ -232,7 +238,10 @@ func flattenConditionRemedyMethods(in []openapi.ConditionAllOfRemedyMethods) []m
 func resourceAppgateConditionUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating condition: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConditionsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.ConditionsIdGet(ctx, d.Id())
@@ -293,7 +302,10 @@ func resourceAppgateConditionUpdate(d *schema.ResourceData, meta interface{}) er
 func resourceAppgateConditionDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete condition with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConditionsApi
 
 	// Get condition

--- a/appgate/resource_appgate_condition_test.go
+++ b/appgate/resource_appgate_condition_test.go
@@ -73,7 +73,10 @@ resource "appgatesdp_condition" "test_condition" {
 
 func testAccCheckConditionExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ConditionsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -85,8 +88,7 @@ func testAccCheckConditionExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.ConditionsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.ConditionsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching condition with resource %s. %s", resource, err)
 		}
 		return nil
@@ -99,11 +101,13 @@ func testAccCheckConditionDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.ConditionsApi
 
-		_, _, err := api.ConditionsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.ConditionsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Condition still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_criteria_script.go
+++ b/appgate/resource_appgate_criteria_script.go
@@ -63,7 +63,10 @@ func resourceAppgateCriteriaScript() *schema.Resource {
 
 func resourceAppgateCriteriaScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Criteria script: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.CriteriaScriptsApi
 	args := openapi.NewCriteriaScriptWithDefaults()
 	args.Id = uuid.New().String()
@@ -90,7 +93,10 @@ func resourceAppgateCriteriaScriptCreate(d *schema.ResourceData, meta interface{
 
 func resourceAppgateCriteriaScriptRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Criteria script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.CriteriaScriptsApi
 	ctx := context.TODO()
 	request := api.CriteriaScriptsIdGet(ctx, d.Id())
@@ -113,7 +119,10 @@ func resourceAppgateCriteriaScriptRead(d *schema.ResourceData, meta interface{})
 func resourceAppgateCriteriaScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Criteria script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Updating Criteria script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.CriteriaScriptsApi
 	ctx := context.TODO()
 	request := api.CriteriaScriptsIdGet(ctx, d.Id())
@@ -150,13 +159,13 @@ func resourceAppgateCriteriaScriptUpdate(d *schema.ResourceData, meta interface{
 func resourceAppgateCriteriaScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Criteria script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Reading Criteria script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.CriteriaScriptsApi
 
-	request := api.CriteriaScriptsIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.CriteriaScriptsIdDelete(context.Background(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Criteria script %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_criteria_script_test.go
+++ b/appgate/resource_appgate_criteria_script_test.go
@@ -53,7 +53,10 @@ resource "appgatesdp_criteria_script" "test_criteria_script" {
 
 func testAccCheckCriteriaScriptExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.CriteriaScriptsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -65,8 +68,7 @@ func testAccCheckCriteriaScriptExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.CriteriaScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.CriteriaScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching criteria script with resource %s. %s", resource, err)
 		}
 		return nil
@@ -79,11 +81,13 @@ func testAccCheckCriteriaScriptDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.CriteriaScriptsApi
 
-		_, _, err := api.CriteriaScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.CriteriaScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Criteria script still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_device_script.go
+++ b/appgate/resource_appgate_device_script.go
@@ -82,7 +82,10 @@ func resourceAppgateDeviceScript() *schema.Resource {
 
 func resourceAppgateDeviceScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Device script: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 	args := openapi.NewDeviceScriptWithDefaults()
 	args.Id = uuid.New().String()
@@ -115,7 +118,10 @@ func resourceAppgateDeviceScriptCreate(d *schema.ResourceData, meta interface{})
 
 func resourceAppgateDeviceScriptRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Device script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 	ctx := context.TODO()
 	request := api.DeviceScriptsIdGet(ctx, d.Id())
@@ -138,7 +144,10 @@ func resourceAppgateDeviceScriptRead(d *schema.ResourceData, meta interface{}) e
 func resourceAppgateDeviceScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Device script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Updating Device script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 	ctx := context.TODO()
 	request := api.DeviceScriptsIdGet(ctx, d.Id())
@@ -181,13 +190,13 @@ func resourceAppgateDeviceScriptUpdate(d *schema.ResourceData, meta interface{})
 func resourceAppgateDeviceScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Device script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Reading Device script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 
-	request := api.DeviceScriptsIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.DeviceScriptsIdDelete(context.Background(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Device script %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_device_script_test.go
+++ b/appgate/resource_appgate_device_script_test.go
@@ -61,7 +61,10 @@ EOF
 
 func testAccCheckDeviceScriptExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.DeviceClaimScriptsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -73,8 +76,7 @@ func testAccCheckDeviceScriptExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching device script with resource %s. %s", resource, err)
 		}
 		return nil
@@ -87,11 +89,13 @@ func testAccCheckDeviceScriptDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.DeviceClaimScriptsApi
 
-		_, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.DeviceScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Device script still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -260,7 +260,10 @@ func resourceAppgateEntitlementRuleCreate(ctx context.Context, d *schema.Resourc
 	var diags diag.Diagnostics
 
 	log.Printf("[DEBUG] Creating Entitlement: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.EntitlementsApi
 
 	args := openapi.NewEntitlementWithDefaults()
@@ -327,7 +330,10 @@ func resourceAppgateEntitlementRuleRead(ctx context.Context, d *schema.ResourceD
 
 	log.Printf("[DEBUG] Reading Entitlement Name: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Reading Entitlement id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.EntitlementsApi
 
 	request := api.EntitlementsIdGet(ctx, d.Id())
@@ -430,7 +436,10 @@ func resourceAppgateEntitlementRuleUpdate(ctx context.Context, d *schema.Resourc
 	log.Printf("[DEBUG] Updating Entitlement: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Updating Entitlement id: %+v", d.Id())
 	var diags diag.Diagnostics
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.EntitlementsApi
 
 	request := api.EntitlementsIdGet(ctx, d.Id())
@@ -514,13 +523,13 @@ func resourceAppgateEntitlementRuleDelete(ctx context.Context, d *schema.Resourc
 	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Delete Entitlement: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Reading Entitlement id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.EntitlementsApi
 
-	request := api.EntitlementsIdDelete(context.Background(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.EntitlementsIdDelete(context.Background(), d.Id()).Authorization(token).Execute(); err != nil {
 		return diag.FromErr(fmt.Errorf("Could not delete Entitlement %+v", prettyPrintAPIError(err)))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_entitlement_script.go
+++ b/appgate/resource_appgate_entitlement_script.go
@@ -68,7 +68,10 @@ func resourceAppgateEntitlementScript() *schema.Resource {
 
 func resourceAppgateEntitlementScriptCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Entitlement script: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.EntitlementScriptsApi
 	args := openapi.NewEntitlementScriptWithDefaults()
 	args.Id = uuid.New().String()
@@ -98,7 +101,10 @@ func resourceAppgateEntitlementScriptCreate(d *schema.ResourceData, meta interfa
 
 func resourceAppgateEntitlementScriptRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Entitlement script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.EntitlementScriptsApi
 	ctx := context.TODO()
 	request := api.EntitlementScriptsIdGet(ctx, d.Id())
@@ -122,7 +128,10 @@ func resourceAppgateEntitlementScriptRead(d *schema.ResourceData, meta interface
 func resourceAppgateEntitlementScriptUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Entitlement script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Updating Entitlement script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.EntitlementScriptsApi
 	ctx := context.TODO()
 	request := api.EntitlementScriptsIdGet(ctx, d.Id())
@@ -163,13 +172,13 @@ func resourceAppgateEntitlementScriptUpdate(d *schema.ResourceData, meta interfa
 func resourceAppgateEntitlementScriptDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Entitlement script: %s", d.Get("name").(string))
 	log.Printf("[DEBUG] Reading Entitlement script id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.EntitlementScriptsApi
 
-	request := api.EntitlementScriptsIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.EntitlementScriptsIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Entitlement script %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_entitlement_script_test.go
+++ b/appgate/resource_appgate_entitlement_script_test.go
@@ -56,7 +56,11 @@ resource "appgatesdp_entitlement_script" "test_entitlement_script" {
 
 func testAccCheckEntitlementScriptExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
+
 		api := testAccProvider.Meta().(*Client).API.EntitlementScriptsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -68,8 +72,7 @@ func testAccCheckEntitlementScriptExists(resource string) resource.TestCheckFunc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.EntitlementScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.EntitlementScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching entitlement script with resource %s. %s", resource, err)
 		}
 		return nil
@@ -82,11 +85,13 @@ func testAccCheckEntitlementScriptDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.EntitlementScriptsApi
 
-		_, _, err := api.EntitlementScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.EntitlementScriptsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Criteria script still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_entitlement_test.go
+++ b/appgate/resource_appgate_entitlement_test.go
@@ -76,11 +76,13 @@ func testAccCheckItemDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.EntitlementsApi
 
-		_, _, err := api.EntitlementsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.EntitlementsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Entitlement still exists, %+v", err)
 		}
 	}
@@ -135,7 +137,10 @@ resource "appgatesdp_entitlement" "test_ping_item" {
 
 func testAccCheckEntitlementExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.EntitlementsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -147,8 +152,7 @@ func testAccCheckEntitlementExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.EntitlementsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.EntitlementsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching item with resource %s. %s", resource, err)
 		}
 		return nil
@@ -215,13 +219,13 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
 	conditions = [
 	  data.appgatesdp_condition.always.id
 	]
-  
+
 	tags = [
 	  "terraform",
 	  "api-created"
 	]
 	disabled = true
-  
+
 	condition_logic = "and"
 	actions {
 	  action  = "allow"
@@ -229,7 +233,7 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
 	  hosts   = ["192.168.2.255/32"]
 	  ports   = ["53"]
 	}
-  
+
 	app_shortcuts {
 	  name       = "%s"
 	  url        = "https://www.google.com"
@@ -253,13 +257,13 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
 	conditions = [
 	  data.appgatesdp_condition.always.id
 	]
-  
+
 	tags = [
 	  "terraform",
 	  "api-created"
 	]
 	disabled = true
-  
+
 	condition_logic = "and"
 	actions {
 	  action  = "allow"
@@ -271,7 +275,7 @@ resource "appgatesdp_entitlement" "monitor_entitlement" {
 		timeout = 22
 	  }
 	}
-  
+
 	app_shortcuts {
 	  name       = "%s"
 	  url        = "https://www.google.com"

--- a/appgate/resource_appgate_global_settings.go
+++ b/appgate/resource_appgate_global_settings.go
@@ -138,7 +138,10 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Reading Global settings id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.GlobalSettingsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.GlobalSettingsGet(ctx)
@@ -182,7 +185,10 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 
 func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] Updating Global settings")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	api := meta.(*Client).API.GlobalSettingsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.GlobalSettingsGet(ctx)
@@ -263,12 +269,13 @@ func resourceGlobalSettingsDelete(ctx context.Context, d *schema.ResourceData, m
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
 	log.Printf("[DEBUG] Delete Global settings")
-	token := meta.(*Client).Token
-	api := meta.(*Client).API.GlobalSettingsApi
-	request := api.GlobalSettingsDelete(context.TODO())
-
-	_, err := request.Authorization(token).Execute()
+	token, err := meta.(*Client).GetToken()
 	if err != nil {
+		return diag.FromErr(err)
+	}
+	api := meta.(*Client).API.GlobalSettingsApi
+
+	if _, err := api.GlobalSettingsDelete(context.Background()).Authorization(token).Execute(); err != nil {
 		return diag.FromErr(fmt.Errorf("Could not reset Global settings %+v", prettyPrintAPIError(err)))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_global_settings_test.go
+++ b/appgate/resource_appgate_global_settings_test.go
@@ -93,7 +93,9 @@ func TestAccGlobalSettings54ProfileHostname(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
-					currentVersion := testAccProvider.Meta().(*Client).ApplianceVersion
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
 					if currentVersion.LessThan(Appliance54Version) {
 						t.Skipf("Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using %s", currentVersion.String())
 					}

--- a/appgate/resource_appgate_global_settings_test.go
+++ b/appgate/resource_appgate_global_settings_test.go
@@ -55,7 +55,10 @@ resource "appgatesdp_global_settings" "test_global_settings" {
 
 func testAccCheckGlobalSettingsExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.GlobalSettingsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -67,8 +70,7 @@ func testAccCheckGlobalSettingsExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.GlobalSettingsGet(context.Background()).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.GlobalSettingsGet(context.Background()).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching global settings with resource %s. %s", resource, err)
 		}
 		return nil

--- a/appgate/resource_appgate_identity_provider_connector.go
+++ b/appgate/resource_appgate_identity_provider_connector.go
@@ -47,7 +47,10 @@ func resourceAppgateConnectorProviderRuleDelete(d *schema.ResourceData, meta int
 func resourceAppgateConnectorProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	// we aren'ẗ allowed to create new additional local identity providers, but we can update existing
 	// with terraform import.
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConnectorIdentityProvidersApi
 	ctx := context.TODO()
 	connectorIP, err := getBuiltinConnectorProviderUUID(ctx, *api, token)
@@ -79,7 +82,10 @@ func getBuiltinConnectorProviderUUID(ctx context.Context, api openapi.ConnectorI
 func resourceAppgateConnectorProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading connectorIP identity provider")
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConnectorIdentityProvidersApi
 	ctx := context.TODO()
 	connectorIP, err := getBuiltinConnectorProviderUUID(ctx, *api, token)
@@ -117,7 +123,10 @@ func resourceAppgateConnectorProviderRuleRead(d *schema.ResourceData, meta inter
 
 func resourceAppgateConnectorProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating connectorIP identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.ConnectorIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -38,12 +38,15 @@ func resourceAppgateLdapProvider() *schema.Resource {
 
 func resourceAppgateLdapProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating LdapProvider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapIdentityProvidersApi
 	ctx := context.TODO()
 	provider := &openapi.IdentityProvider{}
 	provider.Type = identityProviderLdap
-	provider, err := readProviderFromConfig(d, *provider)
+	provider, err = readProviderFromConfig(d, *provider)
 	if err != nil {
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %s", identityProviderLdap, err)
 	}
@@ -136,7 +139,10 @@ func resourceAppgateLdapProviderRuleCreate(d *schema.ResourceData, meta interfac
 func resourceAppgateLdapProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading ldap identity provider id: %+v", d.Id())
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
@@ -241,7 +247,10 @@ func readLdapPasswordWarningFromConfig(input []interface{}) openapi.LdapProvider
 
 func resourceAppgateLdapProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating ldap identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -51,12 +51,15 @@ func resourceAppgateLdapCertificateProvider() *schema.Resource {
 
 func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating LdapCertificateProvider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapCertificateIdentityProvidersApi
 	ctx := context.TODO()
 	provider := &openapi.IdentityProvider{}
 	provider.Type = identityProviderLdapCertificate
-	provider, err := readProviderFromConfig(d, *provider)
+	provider, err = readProviderFromConfig(d, *provider)
 	if err != nil {
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %s", identityProviderLdapCertificate, err)
 	}
@@ -166,7 +169,10 @@ func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, me
 func resourceAppgateLdapCertificateProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading ldap identity provider id: %+v", d.Id())
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapCertificateIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
@@ -246,7 +252,10 @@ func resourceAppgateLdapCertificateProviderRuleRead(d *schema.ResourceData, meta
 
 func resourceAppgateLdapCertificateProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating ldap identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LdapCertificateIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_ldap_certificate_test.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate_test.go
@@ -193,7 +193,10 @@ EOF
 
 func testAccCheckLdapCertificateIdentityProvidervExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LdapCertificateIdentityProvidersApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -205,8 +208,7 @@ func testAccCheckLdapCertificateIdentityProvidervExists(resource string) resourc
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching ldap identity provider with resource %s. %s", resource, err)
 		}
 		return nil
@@ -219,11 +221,13 @@ func testAccCheckLdapCertificateIdentityProvidervDestroy(s *terraform.State) err
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LdapCertificateIdentityProvidersApi
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("ldap identity provider still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_identity_provider_ldap_test.go
+++ b/appgate/resource_appgate_identity_provider_ldap_test.go
@@ -173,7 +173,10 @@ resource "appgatesdp_ldap_identity_provider" "ldap_test_resource" {
 
 func testAccCheckLdapIdentityProviderExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LdapIdentityProvidersApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -185,8 +188,7 @@ func testAccCheckLdapIdentityProviderExists(resource string) resource.TestCheckF
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching ldap identity provider with resource %s. %s", resource, err)
 		}
 		return nil
@@ -199,11 +201,13 @@ func testAccCheckLdapIdentityProviderDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LdapIdentityProvidersApi
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("ldap identity provider still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_identity_provider_local_database.go
+++ b/appgate/resource_appgate_identity_provider_local_database.go
@@ -52,7 +52,10 @@ func resourceAppgateLocalDatabaseProviderRuleDelete(d *schema.ResourceData, meta
 func resourceAppgateLocalDatabaseProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	// we aren'ẗ allowed to create new additional local identity providers, but we can update existing
 	// with terraform import.
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalDatabaseIdentityProvidersApi
 	ctx := context.TODO()
 	localDatabase, err := getBuiltinLocalDatabaseProviderUUID(ctx, *api, token)
@@ -84,7 +87,10 @@ func getBuiltinLocalDatabaseProviderUUID(ctx context.Context, api openapi.LocalD
 func resourceAppgateLocalDatabaseProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading localDatabase identity provider")
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalDatabaseIdentityProvidersApi
 	ctx := context.TODO()
 	localDatabase, err := getBuiltinLocalDatabaseProviderUUID(ctx, *api, token)
@@ -136,7 +142,10 @@ func resourceAppgateLocalDatabaseProviderRuleRead(d *schema.ResourceData, meta i
 
 func resourceAppgateLocalDatabaseProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating localDatabase identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalDatabaseIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -69,12 +69,15 @@ func resourceAppgateRadiusProvider() *schema.Resource {
 
 func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating RadiusProvider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RadiusIdentityProvidersApi
 	ctx := context.TODO()
 	provider := &openapi.IdentityProvider{}
 	provider.Type = identityProviderRadius
-	provider, err := readProviderFromConfig(d, *provider)
+	provider, err = readProviderFromConfig(d, *provider)
 	if err != nil {
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %s", identityProviderRadius, err)
 	}
@@ -147,7 +150,10 @@ func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interf
 func resourceAppgateRadiusProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading radius identity provider id: %+v", d.Id())
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RadiusIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
@@ -212,7 +218,10 @@ func resourceAppgateRadiusProviderRuleRead(d *schema.ResourceData, meta interfac
 
 func resourceAppgateRadiusProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating radius identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RadiusIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_radius_test.go
+++ b/appgate/resource_appgate_identity_provider_radius_test.go
@@ -190,7 +190,10 @@ resource "appgatesdp_radius_identity_provider" "radius_test_resource" {
 
 func testAccCheckRadiusIdentityProviderExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.RadiusIdentityProvidersApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -202,8 +205,7 @@ func testAccCheckRadiusIdentityProviderExists(resource string) resource.TestChec
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching radius identity provider with resource %s. %s", resource, err)
 		}
 		return nil
@@ -216,11 +218,13 @@ func testAccCheckRadiusIdentityProviderDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.RadiusIdentityProvidersApi
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("radius identity provider still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -62,12 +62,15 @@ func resourceAppgateSamlProvider() *schema.Resource {
 
 func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating SamlProvider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.SamlIdentityProvidersApi
 	ctx := context.TODO()
 	provider := &openapi.IdentityProvider{}
 	provider.Type = identityProviderSaml
-	provider, err := readProviderFromConfig(d, *provider)
+	provider, err = readProviderFromConfig(d, *provider)
 	if err != nil {
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %s", identityProviderSaml, err)
 	}
@@ -140,7 +143,10 @@ func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interfac
 func resourceAppgateSamlProviderRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading saml identity provider id: %+v", d.Id())
 
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.SamlIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
@@ -195,7 +201,10 @@ func resourceAppgateSamlProviderRuleRead(d *schema.ResourceData, meta interface{
 
 func resourceAppgateSamlProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating saml identity provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.SamlIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())

--- a/appgate/resource_appgate_identity_provider_saml_test.go
+++ b/appgate/resource_appgate_identity_provider_saml_test.go
@@ -728,7 +728,10 @@ func testAccCheckSamlIdentityProviderClaimMoves(rName string) string {
 func testAccCheckSamlIdentityProviderExists(resource string) resource.TestCheckFunc {
 
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.SamlIdentityProvidersApi
 		rs, ok := state.RootModule().Resources[resource]
 
@@ -740,8 +743,7 @@ func testAccCheckSamlIdentityProviderExists(resource string) resource.TestCheckF
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching saml identity provider with resource %s. %s", resource, err)
 		}
 		return nil
@@ -754,11 +756,13 @@ func testAccCheckSamlIdentityProviderDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.SamlIdentityProvidersApi
 
-		_, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.IdentityProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("saml identity provider still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_ip_pool.go
+++ b/appgate/resource_appgate_ip_pool.go
@@ -86,7 +86,10 @@ func resourceAppgateIPPool() *schema.Resource {
 
 func resourceAppgateIPPoolCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Ip pool: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IPPoolsApi
 	args := openapi.NewIpPoolWithDefaults()
 	args.Id = uuid.New().String()
@@ -146,7 +149,10 @@ func readIPPoolRangesFromConfig(ranges []interface{}) ([]openapi.IpPoolAllOfRang
 
 func resourceAppgateIPPoolRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Ip pool id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IPPoolsApi
 	ctx := context.TODO()
 	request := api.IpPoolsIdGet(ctx, d.Id())
@@ -191,7 +197,10 @@ func flattenIPPoolRanges(in []openapi.IpPoolAllOfRanges) []map[string]interface{
 
 func resourceAppgateIPPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Ip pool: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IPPoolsApi
 	ctx := context.TODO()
 	request := api.IpPoolsIdGet(ctx, d.Id())
@@ -240,13 +249,13 @@ func resourceAppgateIPPoolUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceAppgateIPPoolDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Ip pool: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.IPPoolsApi
 
-	request := api.IpPoolsIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.IpPoolsIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Ip pool %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_ip_pool_test.go
+++ b/appgate/resource_appgate_ip_pool_test.go
@@ -62,7 +62,10 @@ resource "appgatesdp_ip_pool" "test_ip_pool_v4" {
 
 func testAccCheckIPPoolExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.IPPoolsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -74,9 +77,8 @@ func testAccCheckIPPoolExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.IpPoolsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
-			return fmt.Errorf("error fetching device script with resource %s. %s", resource, err)
+		if _, _, err := api.IpPoolsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
+			return fmt.Errorf("error fetching ip pool with resource %s. %s", resource, err)
 		}
 		return nil
 	}
@@ -88,11 +90,13 @@ func testAccCheckIPPoolDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.IPPoolsApi
 
-		_, _, err := api.IpPoolsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.IpPoolsIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Device script still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_license.go
+++ b/appgate/resource_appgate_license.go
@@ -42,13 +42,15 @@ func resourceAppgateLicense() *schema.Resource {
 
 func resourceAppgateLicenseCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating license")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LicenseApi
 	args := openapi.NewLicenseImportWithDefaults()
 	args.SetLicense(d.Get("license").(string))
-	request := api.LicensePost(context.TODO())
-	_, _, err := request.LicenseImport(*args).Authorization(token).Execute()
-	if err != nil {
+
+	if _, _, err := api.LicensePost(context.TODO()).LicenseImport(*args).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not create license %+v", prettyPrintAPIError(err))
 	}
 	return resourceAppgateLicenseRead(d, meta)
@@ -60,7 +62,10 @@ func getLicenseIdentifier(license openapi.LicenseDetails) string {
 
 func resourceAppgateLicenseRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading license")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LicenseApi
 	ctx := context.TODO()
 	request := api.LicenseGet(ctx)
@@ -76,13 +81,13 @@ func resourceAppgateLicenseRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceAppgateLicenseDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete license")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LicenseApi
 
-	request := api.LicenseDelete(context.TODO())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.LicenseDelete(context.TODO()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete license %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_local_user.go
+++ b/appgate/resource_appgate_local_user.go
@@ -78,7 +78,10 @@ func resourceAppgateLocalUser() *schema.Resource {
 
 func resourceAppgateLocalUserCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Local user: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalUsersApi
 	args := openapi.NewLocalUserWithDefaults()
 	args.Id = uuid.New().String()
@@ -137,7 +140,10 @@ func parseDateTimeString(input string) (*time.Time, error) {
 
 func resourceAppgateLocalUserRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Local user id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalUsersApi
 	ctx := context.TODO()
 	request := api.LocalUsersIdGet(ctx, d.Id())
@@ -167,7 +173,10 @@ func resourceAppgateLocalUserRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAppgateLocalUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Local user: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalUsersApi
 	ctx := context.TODO()
 	request := api.LocalUsersIdGet(ctx, d.Id())
@@ -242,13 +251,13 @@ func resourceAppgateLocalUserUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAppgateLocalUserDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Local user id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.LocalUsersApi
 
-	request := api.LocalUsersIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.LocalUsersIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete Local user %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_local_user_test.go
+++ b/appgate/resource_appgate_local_user_test.go
@@ -65,7 +65,10 @@ resource "appgatesdp_local_user" "test_local_user" {
 
 func testAccCheckLocalUserExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LocalUsersApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -77,8 +80,7 @@ func testAccCheckLocalUserExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.LocalUsersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.LocalUsersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching local user with resource %s. %s", resource, err)
 		}
 		return nil
@@ -91,11 +93,13 @@ func testAccCheckLocalUserDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.LocalUsersApi
 
-		_, _, err := api.LocalUsersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.LocalUsersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("local user still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_mfa_provider.go
+++ b/appgate/resource_appgate_mfa_provider.go
@@ -149,7 +149,10 @@ func resourceAppgateMfaProvider() *schema.Resource {
 
 func resourceAppgateMfaProviderCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating MFA provider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAProvidersApi
 	args := openapi.NewMfaProviderWithDefaults()
 	args.Id = uuid.New().String()
@@ -207,7 +210,10 @@ func resourceAppgateMfaProviderCreate(d *schema.ResourceData, meta interface{}) 
 
 func resourceAppgateMfaProviderRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading MFA provider id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAProvidersApi
 	ctx := context.TODO()
 	request := api.MfaProvidersIdGet(ctx, d.Id())
@@ -236,7 +242,10 @@ func resourceAppgateMfaProviderRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceAppgateMfaProviderUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating MFA provider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAProvidersApi
 	ctx := context.TODO()
 	request := api.MfaProvidersIdGet(ctx, d.Id())
@@ -301,13 +310,13 @@ func resourceAppgateMfaProviderUpdate(d *schema.ResourceData, meta interface{}) 
 
 func resourceAppgateMfaProviderDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete MFA provider: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAProvidersApi
 
-	request := api.MfaProvidersIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.MfaProvidersIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete MFA provider %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_mfa_provider_test.go
+++ b/appgate/resource_appgate_mfa_provider_test.go
@@ -82,7 +82,7 @@ func testAccCheckMfaProviderExists(resource string) resource.TestCheckFunc {
 
 		_, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
 		if err != nil {
-			return fmt.Errorf("error fetching device script with resource %s. %s", resource, err)
+			return fmt.Errorf("error fetching mfa_provider with resource %s. %s", resource, err)
 		}
 		return nil
 	}
@@ -99,7 +99,7 @@ func testAccCheckMfaProviderDestroy(s *terraform.State) error {
 
 		_, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
 		if err == nil {
-			return fmt.Errorf("Device script still exists, %+v", err)
+			return fmt.Errorf("mfa_provider still exists, %+v", err)
 		}
 	}
 	return nil

--- a/appgate/resource_appgate_mfa_provider_test.go
+++ b/appgate/resource_appgate_mfa_provider_test.go
@@ -68,7 +68,10 @@ resource "appgatesdp_mfa_provider" "test_mfa_provider" {
 
 func testAccCheckMfaProviderExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.MFAProvidersApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -80,8 +83,7 @@ func testAccCheckMfaProviderExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching mfa_provider with resource %s. %s", resource, err)
 		}
 		return nil
@@ -94,11 +96,13 @@ func testAccCheckMfaProviderDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.MFAProvidersApi
 
-		_, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.MfaProvidersIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("mfa_provider still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_mfa_setting.go
+++ b/appgate/resource_appgate_mfa_setting.go
@@ -40,7 +40,10 @@ func resourceAdminMfaSettingsCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAdminMfaSettingsRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading MFA admin settings id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAForAdminsApi
 	ctx := context.TODO()
 	request := api.AdminMfaSettingsGet(ctx)
@@ -61,7 +64,10 @@ func resourceAdminMfaSettingsRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceAdminMfaSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating MFA admin settings")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAForAdminsApi
 	ctx := context.TODO()
 	request := api.AdminMfaSettingsGet(ctx)
@@ -95,13 +101,13 @@ func resourceAdminMfaSettingsUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceAdminMfaSettingsDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete/Resetting MFA admin settings")
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.MFAForAdminsApi
 
-	request := api.AdminMfaSettingsDelete(context.TODO())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.AdminMfaSettingsDelete(context.TODO()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could reset MFA admin settings %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_mfa_setting_test.go
+++ b/appgate/resource_appgate_mfa_setting_test.go
@@ -46,7 +46,10 @@ resource "appgatesdp_admin_mfa_settings" "test_example_mfa_settings" {
 
 func testAccCheckAdminMfaSettingsExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.MFAForAdminsApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -58,8 +61,7 @@ func testAccCheckAdminMfaSettingsExists(resource string) resource.TestCheckFunc 
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.AdminMfaSettingsGet(context.Background()).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.AdminMfaSettingsGet(context.Background()).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching AdminMfaSettings with resource %s. %s", resource, err)
 		}
 		return nil

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -156,7 +156,10 @@ func resourceAppgatePolicy() *schema.Resource {
 func resourceAppgatePolicyCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Policy with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.PoliciesApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	args := openapi.NewPolicyWithDefaults()
@@ -287,7 +290,10 @@ func readProxyAutoConfigFromConfig(proxyAutoConfigs []interface{}) openapi.Polic
 func resourceAppgatePolicyRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading Policy with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.PoliciesApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.PoliciesIdGet(ctx, d.Id())
@@ -358,7 +364,10 @@ func flattenTrustedNetworkCheck(in openapi.PolicyAllOfTrustedNetworkCheck) ([]in
 func resourceAppgatePolicyUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating policy: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.PoliciesApi
 	request := api.PoliciesIdGet(ctx, d.Id())
 	orginalPolicy, _, err := request.Authorization(token).Execute()
@@ -462,7 +471,10 @@ func resourceAppgatePolicyUpdate(d *schema.ResourceData, meta interface{}) error
 func resourceAppgatePolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Policy with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.PoliciesApi
 
 	// Get policy

--- a/appgate/resource_appgate_policy_test.go
+++ b/appgate/resource_appgate_policy_test.go
@@ -79,7 +79,10 @@ resource "appgatesdp_policy" "test_policy" {
 
 func testAccCheckPolicyExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.PoliciesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -91,8 +94,7 @@ func testAccCheckPolicyExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.PoliciesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.PoliciesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching policy with resource %s. %s", resource, err)
 		}
 		return nil
@@ -105,11 +107,13 @@ func testAccCheckPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.PoliciesApi
 
-		_, _, err := api.PoliciesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.PoliciesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("policy still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_ringfence_rule.go
+++ b/appgate/resource_appgate_ringfence_rule.go
@@ -133,7 +133,10 @@ func resourceAppgateRingfenceRule() *schema.Resource {
 func resourceAppgateRingfenceRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating Ringfence rule with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RingfenceRulesApi
 
 	args := openapi.NewRingfenceRuleWithDefaults()
@@ -167,7 +170,10 @@ func resourceAppgateRingfenceRuleCreate(d *schema.ResourceData, meta interface{}
 func resourceAppgateRingfenceRuleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Read Ringfence rule with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RingfenceRulesApi
 	request := api.RingfenceRulesIdGet(ctx, d.Id())
 	ringfenceRule, _, err := request.Authorization(token).Execute()
@@ -216,7 +222,10 @@ func flattenRingfenceActions(in []openapi.RingfenceRuleAllOfActions) []map[strin
 func resourceAppgateRingfenceRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating Ringfence rule with name: %s", d.Get("name").(string))
 	ctx := context.Background()
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RingfenceRulesApi
 	request := api.RingfenceRulesIdGet(ctx, d.Id())
 	originalRingfenceRule, _, err := request.Authorization(token).Execute()
@@ -255,7 +264,10 @@ func resourceAppgateRingfenceRuleUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceAppgateRingfenceRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete Ringfence rule: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.RingfenceRulesApi
 	ctx := context.Background()
 

--- a/appgate/resource_appgate_ringfence_rule_test.go
+++ b/appgate/resource_appgate_ringfence_rule_test.go
@@ -143,7 +143,10 @@ resource "appgatesdp_ringfence_rule" "test_ringfence_rule_tcp" {
 
 func testAccCheckRingfenceRuleExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.RingfenceRulesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -155,8 +158,7 @@ func testAccCheckRingfenceRuleExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.RingfenceRulesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.RingfenceRulesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching ringfence rule with resource %s. %s", resource, err)
 		}
 		return nil
@@ -169,11 +171,13 @@ func testAccCheckRingfenceRuleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.RingfenceRulesApi
 
-		_, _, err := api.RingfenceRulesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.RingfenceRulesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("RingfenceRule still exists, %+v", err)
 		}
 	}

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -150,11 +150,13 @@ func testAccCheckSiteDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.SitesApi
 
-		_, _, err := api.SitesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.SitesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("Site still exists, %+v", err)
 		}
 	}
@@ -398,7 +400,10 @@ resource "appgatesdp_site" "test_site" {
 
 func testAccCheckSiteExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.SitesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -410,8 +415,7 @@ func testAccCheckSiteExists(resource string) resource.TestCheckFunc {
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.SitesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.SitesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching item with resource %s. %s", resource, err)
 		}
 		return nil

--- a/appgate/resource_appgate_trusted_certificate.go
+++ b/appgate/resource_appgate_trusted_certificate.go
@@ -47,7 +47,10 @@ func resourceAppgateTrustedCertificate() *schema.Resource {
 
 func resourceAppgateTrustedCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Creating trusted certificate: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.TrustedCertificatesApi
 	args := openapi.NewTrustedCertificateWithDefaults()
 	args.Id = uuid.New().String()
@@ -75,7 +78,10 @@ func resourceAppgateTrustedCertificateCreate(d *schema.ResourceData, meta interf
 
 func resourceAppgateTrustedCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading trusted certificate id: %+v", d.Id())
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.TrustedCertificatesApi
 	ctx := context.TODO()
 	request := api.TrustedCertificatesIdGet(ctx, d.Id())
@@ -97,7 +103,10 @@ func resourceAppgateTrustedCertificateRead(d *schema.ResourceData, meta interfac
 
 func resourceAppgateTrustedCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating trusted certificate: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.TrustedCertificatesApi
 	ctx := context.TODO()
 	request := api.TrustedCertificatesIdGet(ctx, d.Id())
@@ -133,13 +142,13 @@ func resourceAppgateTrustedCertificateUpdate(d *schema.ResourceData, meta interf
 
 func resourceAppgateTrustedCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Delete trusted certificate: %s", d.Get("name").(string))
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return err
+	}
 	api := meta.(*Client).API.TrustedCertificatesApi
 
-	request := api.TrustedCertificatesIdDelete(context.TODO(), d.Id())
-
-	_, err := request.Authorization(token).Execute()
-	if err != nil {
+	if _, err := api.TrustedCertificatesIdDelete(context.TODO(), d.Id()).Authorization(token).Execute(); err != nil {
 		return fmt.Errorf("Could not delete trusted certificate %+v", prettyPrintAPIError(err))
 	}
 	d.SetId("")

--- a/appgate/resource_appgate_trusted_certificate_test.go
+++ b/appgate/resource_appgate_trusted_certificate_test.go
@@ -70,7 +70,10 @@ EOF
 
 func testAccCheckTrustedCertificateExists(resource string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.TrustedCertificatesApi
 
 		rs, ok := state.RootModule().Resources[resource]
@@ -82,8 +85,7 @@ func testAccCheckTrustedCertificateExists(resource string) resource.TestCheckFun
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		_, _, err := api.TrustedCertificatesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err != nil {
+		if _, _, err := api.TrustedCertificatesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err != nil {
 			return fmt.Errorf("error fetching trusted certificate with resource %s. %s", resource, err)
 		}
 		return nil
@@ -96,11 +98,13 @@ func testAccCheckTrustedCertificateDestroy(s *terraform.State) error {
 			continue
 		}
 
-		token := testAccProvider.Meta().(*Client).Token
+		token, err := testAccProvider.Meta().(*Client).GetToken()
+		if err != nil {
+			return err
+		}
 		api := testAccProvider.Meta().(*Client).API.TrustedCertificatesApi
 
-		_, _, err := api.TrustedCertificatesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute()
-		if err == nil {
+		if _, _, err := api.TrustedCertificatesIdGet(context.Background(), rs.Primary.ID).Authorization(token).Execute(); err == nil {
 			return fmt.Errorf("trusted certificate still exists, %+v", err)
 		}
 	}

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -214,7 +214,10 @@ func Nprintf(format string, params map[string]interface{}) string {
 
 func applianceStatsRetryable(ctx context.Context, meta interface{}) *resource.RetryError {
 	statsAPI := meta.(*Client).API.ApplianceStatsApi
-	token := meta.(*Client).Token
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return resource.RetryableError(err)
+	}
 	stats, _, err := statsAPI.StatsAppliancesGet(ctx).Authorization(token).Execute()
 	if err != nil {
 		return resource.RetryableError(err)

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -68,12 +68,36 @@ $ export APPGATE_INSECURE="true"
 $ terraform plan
 ```
 
+### Config file
+
+Configure appgatesdp with a config file, can be combined with environment variables, if an `APPGATE_` environment variable is set, they take precedence over the config file.
+
+```hcl
+provider "appgatesdp" {
+  config_path = var.appgate_config_file
+}
+```
+
+example config file format
+```json
+{
+    "appgate_url": "https://controller.appgate/admin",
+    "appgate_username": "admin",
+    "appgate_password": "admin",
+    "appgate_provider": "local",
+    "appgate_client_version": 15,
+    "appgate_insecure": true
+}
+
+```
 
 ## Argument Reference
 
 In addition to [generic `provider` arguments](https://www.terraform.io/docs/configuration/providers.html)
 (e.g. `alias` and `version`), the following arguments are supported in the Appgate
  `provider` block:
+
+* `config_path` - (Optional) Configure appgatesdp with a config file, if any environment variables is set, they take precedence.
 
 * `username` - (Optional) This is the Appgate username. It must be provided, but
   it can also be sourced from the `APPGATE_USERNAME` environment variable.


### PR DESCRIPTION
Add support to configure the `provider {}` block with a `config_file`

<details>

Acceptance test for 5.4.1-25150-release
```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
=== RUN   TestConfigGetToken/test_5.4_login
=== RUN   TestConfigGetToken/invalid_client_version
--- PASS: TestConfigGetToken (0.00s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (11.16s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.97s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.56s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.61s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.58s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.85s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.78s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.79s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.84s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.97s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccApplianceBasicController
=== CONT  TestAccApplianceConnector
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccSiteBasic
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.35s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.51s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.67s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccDeviceScriptBasic (8.81s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (9.26s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccadministrativeRoleBasic (9.43s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccRingfenceRuleBasicICMP (9.51s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccRingfenceRuleBasicTCP (9.63s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccCriteriaScriptBasic (9.66s)
=== CONT  TestAccGlobalSettingsBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (8.70s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccIPPoolBasic (10.22s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccEntitlementScriptBasic (10.44s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccTrustedCertificateBasic (10.46s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccadministrativeRoleWithScope (11.38s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccApplianceBasicGateway (11.62s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccApplianceConnector (11.81s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccEntitlementBasicPing (12.28s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccApplianceCustomizationBasic (13.24s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccAppgateMfaProviderDataSource (7.04s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (7.52s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccGlobalSettingsBasic (8.30s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccGlobalSettings54ProfileHostname (8.55s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccBlacklistUserBasic (5.95s)
--- PASS: TestAccAdminMfaSettingsBasic (8.19s)
--- PASS: TestAccMfaProviderBasic (7.83s)
--- PASS: TestAccLocalUserBasic (7.00s)
--- PASS: TestAccPolicyBasic (8.87s)
--- PASS: TestAccRadiusIdentityProviderBasic (10.71s)
--- PASS: TestAccConditionBasic (7.10s)
--- PASS: TestAccLdapIdentityProviderBasic (11.70s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (11.64s)
--- PASS: TestAccSiteBasic (22.58s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (8.60s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (7.23s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (16.65s)
--- PASS: TestAccApplianceBasicController (25.61s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (14.77s)
--- PASS: TestAccEntitlementUpdateActionOrder (14.59s)
--- PASS: TestAccEntitlementBasicWithMonitor (15.80s)
--- PASS: TestAccSamlIdentityProviderBasic (28.56s)
--- PASS: TestAccClientProfileBasic (17.09s)
--- PASS: TestAccAppliancePortalSetup (23.20s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	89.298s
```
</details>


<details>

test result for 5.3.4-24950 
```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
=== RUN   TestConfigGetToken/test_5.4_login
=== RUN   TestConfigGetToken/invalid_client_version
--- PASS: TestConfigGetToken (0.00s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.54s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.86s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.05s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.43s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.54s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.62s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.12s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.61s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.99s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.68s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccPolicyBasic
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.4-0
--- SKIP: TestAccGlobalSettings54ProfileHostname (1.28s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccAdminMfaSettingsBasic (7.70s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.15s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccRingfenceRuleBasicICMP (8.40s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccIPPoolBasic (8.65s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccTrustedCertificateBasic (8.71s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccGlobalSettingsBasic (9.08s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccMfaProviderBasic (9.10s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccRingfenceRuleBasicTCP (9.10s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccLocalUserBasic (9.19s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.46s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccPolicyBasic (10.12s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2171: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.41s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (10.86s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccEntitlementBasicPing (11.25s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccLdapIdentityProviderBasic (11.58s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccRadiusIdentityProviderBasic (12.01s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.36s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccBlacklistUserBasic (7.03s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccDeviceScriptBasic (8.06s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccEntitlementScriptBasic (8.36s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccCriteriaScriptBasic (8.14s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccConditionBasic (8.15s)
--- PASS: TestAccApplianceBasicGateway (10.35s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.16s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (9.77s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (19.66s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.65s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (20.10s)
--- PASS: TestAccApplianceConnector (9.57s)
--- PASS: TestAccEntitlementUpdateActionOrder (19.20s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.61s)
--- PASS: TestAccAppgateMfaProviderDataSource (5.57s)
--- PASS: TestAccSiteBasic (22.41s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.60s)
--- PASS: TestAccadministrativeRoleBasic (6.13s)
--- PASS: TestAccApplianceCustomizationBasic (11.31s)
--- PASS: TestAccadministrativeRoleWithScope (7.63s)
--- PASS: TestAccEntitlementBasicWithMonitor (16.07s)
--- PASS: TestAccSamlIdentityProviderBasic (26.55s)
--- PASS: TestAccApplianceBasicController (17.90s)
--- PASS: TestAccClientProfileBasic (27.29s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	81.856s

```

</details>