### PR TITLE
Add check for resource not found all around

### DIFF
--- a/appgate/data_source_appgate_appliance_seed.go
+++ b/appgate/data_source_appgate_appliance_seed.go
@@ -5,6 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
 
@@ -62,9 +63,12 @@ func dataSourceAppgateApplianceSeedRead(d *schema.ResourceData, meta interface{}
 	}
 
 	request := api.AppliancesIdGet(ctx, applianceID.(string))
-	appliance, _, err := request.Authorization(token).Execute()
+	appliance, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Appliance, %+v", err)
 	}
 	if ok, _ := appliance.GetActivatedOk(); *ok {

--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
 
@@ -244,10 +245,12 @@ func resourceAppgateAdministrativeRoleRead(ctx context.Context, d *schema.Resour
 	}
 	api := meta.(*Client).API.AdministrativeRolesApi
 	request := api.AdministrativeRolesIdGet(ctx, d.Id())
-	administrativeRole, _, err := request.Authorization(token).Execute()
+	administrativeRole, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("Failed to read Administrative role, %+v", err))
 	}
 	d.SetId(administrativeRole.Id)

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"time"
 
@@ -1470,9 +1471,12 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 	currentVersion := meta.(*Client).ApplianceVersion
 	ctx := context.Background()
 	request := api.AppliancesIdGet(ctx, d.Id())
-	appliance, _, err := request.Authorization(token).Execute()
+	appliance, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Appliance, %+v", err)
 	}
 	d.Set("appliance_id", appliance.Id)

--- a/appgate/resource_appgate_appliance_customization.go
+++ b/appgate/resource_appgate_appliance_customization.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"time"
 
@@ -155,9 +156,12 @@ func resourceAppgateApplianceCustomizationRead(d *schema.ResourceData, meta inte
 	api := meta.(*Client).API.ApplianceCustomizationsApi
 	ctx := context.TODO()
 	request := api.ApplianceCustomizationsIdGet(ctx, d.Id())
-	customization, _, err := request.Authorization(token).Execute()
+	customization, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Appliance customization, %+v", err)
 	}
 	d.SetId(customization.Id)

--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -196,9 +197,12 @@ func resourceAppgateConditionRead(d *schema.ResourceData, meta interface{}) erro
 	currentVersion := meta.(*Client).ApplianceVersion
 	ctx := context.Background()
 	request := api.ConditionsIdGet(ctx, d.Id())
-	remoteCondition, _, err := request.Authorization(token).Execute()
+	remoteCondition, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Condition, %+v", err)
 	}
 	d.SetId(remoteCondition.Id)

--- a/appgate/resource_appgate_criteria_script.go
+++ b/appgate/resource_appgate_criteria_script.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -100,10 +101,12 @@ func resourceAppgateCriteriaScriptRead(d *schema.ResourceData, meta interface{})
 	api := meta.(*Client).API.CriteriaScriptsApi
 	ctx := context.TODO()
 	request := api.CriteriaScriptsIdGet(ctx, d.Id())
-	criteraScript, _, err := request.Authorization(token).Execute()
+	criteraScript, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Criteria script, %+v", err)
 	}
 	d.SetId(criteraScript.Id)

--- a/appgate/resource_appgate_device_script.go
+++ b/appgate/resource_appgate_device_script.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -125,10 +126,12 @@ func resourceAppgateDeviceScriptRead(d *schema.ResourceData, meta interface{}) e
 	api := meta.(*Client).API.DeviceClaimScriptsApi
 	ctx := context.TODO()
 	request := api.DeviceScriptsIdGet(ctx, d.Id())
-	deviceScript, _, err := request.Authorization(token).Execute()
+	deviceScript, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Device script, %+v", err)
 	}
 	d.SetId(deviceScript.Id)

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"sort"
 	"time"
 
@@ -337,10 +338,12 @@ func resourceAppgateEntitlementRuleRead(ctx context.Context, d *schema.ResourceD
 	api := meta.(*Client).API.EntitlementsApi
 
 	request := api.EntitlementsIdGet(ctx, d.Id())
-	entitlement, _, err := request.Authorization(token).Execute()
+	entitlement, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("Failed to read Entitlement, %+v", err))
 	}
 	d.SetId(entitlement.Id)

--- a/appgate/resource_appgate_entitlement_script.go
+++ b/appgate/resource_appgate_entitlement_script.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -108,10 +109,12 @@ func resourceAppgateEntitlementScriptRead(d *schema.ResourceData, meta interface
 	api := meta.(*Client).API.EntitlementScriptsApi
 	ctx := context.TODO()
 	request := api.EntitlementScriptsIdGet(ctx, d.Id())
-	EntitlementScript, _, err := request.Authorization(token).Execute()
+	EntitlementScript, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Entitlement script, %+v", err)
 	}
 	d.SetId(EntitlementScript.Id)

--- a/appgate/resource_appgate_global_settings.go
+++ b/appgate/resource_appgate_global_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -145,9 +146,12 @@ func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, met
 	api := meta.(*Client).API.GlobalSettingsApi
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.GlobalSettingsGet(ctx)
-	settings, _, err := request.Authorization(token).Execute()
+	settings, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("Failed to read Global settings, %+v", err))
 	}
 	d.SetId(settings.GetCollectiveId())

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -146,9 +147,12 @@ func resourceAppgateLdapProviderRuleRead(d *schema.ResourceData, meta interface{
 	api := meta.(*Client).API.LdapIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
-	ldap, _, err := request.Authorization(token).Execute()
+	ldap, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read LDAP Identity provider, %+v", err)
 	}
 	d.Set("type", identityProviderLdap)

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
 
@@ -176,9 +177,12 @@ func resourceAppgateLdapCertificateProviderRuleRead(d *schema.ResourceData, meta
 	api := meta.(*Client).API.LdapCertificateIdentityProvidersApi
 	ctx := context.TODO()
 	request := api.IdentityProvidersIdGet(ctx, d.Id())
-	ldap, _, err := request.Authorization(token).Execute()
+	ldap, res, err := request.Authorization(token).Execute()
 	if err != nil {
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read LDAP Identity provider, %+v", err)
 	}
 	d.Set("type", identityProviderLdapCertificate)

--- a/appgate/resource_appgate_ip_pool.go
+++ b/appgate/resource_appgate_ip_pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -156,10 +157,12 @@ func resourceAppgateIPPoolRead(d *schema.ResourceData, meta interface{}) error {
 	api := meta.(*Client).API.IPPoolsApi
 	ctx := context.TODO()
 	request := api.IpPoolsIdGet(ctx, d.Id())
-	IPPool, _, err := request.Authorization(token).Execute()
+	IPPool, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Ip pool, %+v", err)
 	}
 	d.SetId(IPPool.Id)

--- a/appgate/resource_appgate_mfa_provider.go
+++ b/appgate/resource_appgate_mfa_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -217,10 +218,12 @@ func resourceAppgateMfaProviderRead(d *schema.ResourceData, meta interface{}) er
 	api := meta.(*Client).API.MFAProvidersApi
 	ctx := context.TODO()
 	request := api.MfaProvidersIdGet(ctx, d.Id())
-	mfaProvider, _, err := request.Authorization(token).Execute()
+	mfaProvider, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read MFA provider, %+v", err)
 	}
 	d.SetId(mfaProvider.Id)

--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -522,10 +523,12 @@ func resourceAppgateSiteRead(d *schema.ResourceData, meta interface{}) error {
 	currentVersion := meta.(*Client).ApplianceVersion
 
 	request := api.SitesIdGet(context.Background(), d.Id())
-	site, _, err := request.Authorization(token).Execute()
+	site, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Site, %+v", err)
 	}
 
@@ -792,10 +795,12 @@ func resourceAppgateSiteUpdate(d *schema.ResourceData, meta interface{}) error {
 	currentVersion := meta.(*Client).ApplianceVersion
 	request := api.SitesIdGet(context.Background(), d.Id())
 
-	orginalSite, _, err := request.Authorization(token).Execute()
+	orginalSite, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read Site, %+v", err)
 	}
 

--- a/appgate/resource_appgate_trusted_certificate.go
+++ b/appgate/resource_appgate_trusted_certificate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
@@ -85,10 +86,12 @@ func resourceAppgateTrustedCertificateRead(d *schema.ResourceData, meta interfac
 	api := meta.(*Client).API.TrustedCertificatesApi
 	ctx := context.TODO()
 	request := api.TrustedCertificatesIdGet(ctx, d.Id())
-	trustedCertificate, _, err := request.Authorization(token).Execute()
+	trustedCertificate, res, err := request.Authorization(token).Execute()
 	if err != nil {
-		// TODO check if 404
 		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		return fmt.Errorf("Failed to read trusted certificate, %+v", err)
 	}
 	d.SetId(trustedCertificate.Id)


### PR DESCRIPTION
This PR adds checks for resources in case they are manually deleted, and thus not in sync with the state. These checks will remove manually removed resources from the state when they are not found.

Fixes: #152 