### PR TITLE
appliance.admin_interface remove correctly

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
 
@@ -49,12 +48,6 @@ func resourceAppgateAppliance() *schema.Resource {
 		Delete: resourceAppgateApplianceDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		SchemaVersion: 1,

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -2332,3 +2332,245 @@ resource "appgatesdp_appliance" "test_portal" {
 }
 `, context)
 }
+
+// Test with admin_interface, then removed.
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/153
+func TestAccApplianceAdminInterfaceAddRemove(t *testing.T) {
+	resourceName := "appgatesdp_appliance.appliance_one"
+	rName := RandStringFromCharSet(15, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":     rName,
+		"hostname": fmt.Sprintf("%s.devops", rName),
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApplianceDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApplianceWithAdminInterface(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "true"),
+
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.https_port", "444"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.https_ciphers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.https_ciphers.0", "ECDHE-RSA-AES256-GCM-SHA384"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.https_ciphers.1", "ECDHE-RSA-AES128-GCM-SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.0.https_port", "443"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccApplianceImportStateCheckFunc(1),
+				ImportStateVerifyIgnore: []string{
+					"site",
+					"seed_file",
+				},
+			},
+			{
+				Config: testAccApplianceWithoutAdminInterface(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "true"),
+
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.https_port", "444"),
+
+					resource.TestCheckResourceAttr(resourceName, "admin_interface.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccApplianceWithAdminInterface(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+  site_name = "Default site"
+}
+resource "appgatesdp_appliance" "appliance_one" {
+	depends_on = [
+      data.appgatesdp_site.default_site
+	]
+	name     = "%{name}"
+	hostname = "%{hostname}"
+
+	client_interface {
+		hostname       = "%{hostname}"
+		proxy_protocol = true
+		https_port     = 8443
+		dtls_port      = 443
+		allow_sources {
+		  address = "0.0.0.0"
+		  netmask = 0
+		}
+		override_spa_mode = "TCP"
+	}
+
+	peer_interface {
+		hostname   = "%{hostname}"
+		https_port = "444"
+
+		allow_sources {
+		  address = "0.0.0.0"
+		  netmask = 0
+		}
+	}
+
+	admin_interface {
+		hostname = "%{hostname}"
+		https_ciphers = [
+		  "ECDHE-RSA-AES256-GCM-SHA384",
+		  "ECDHE-RSA-AES128-GCM-SHA256"
+		]
+	}
+
+	site = data.appgatesdp_site.default_site.id
+	networking {
+		nics {
+		enabled = true
+		name    = "eth0"
+		ipv4 {
+			dhcp {
+			enabled = true
+			dns     = true
+			routers = true
+			ntp     = true
+			}
+		}
+		}
+	}
+	}
+`, context)
+}
+
+func testAccApplianceWithoutAdminInterface(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+  site_name = "Default site"
+}
+resource "appgatesdp_appliance" "appliance_one" {
+	depends_on = [
+		data.appgatesdp_site.default_site
+	]
+	name     = "%{name}"
+	hostname = "%{hostname}"
+
+	client_interface {
+		hostname       = "%{hostname}"
+		proxy_protocol = true
+		https_port     = 8443
+		dtls_port      = 443
+		allow_sources {
+		  address = "0.0.0.0"
+		  netmask = 0
+		}
+		override_spa_mode = "TCP"
+	}
+
+	peer_interface {
+		hostname   = "%{hostname}"
+		https_port = "444"
+
+		allow_sources {
+		  address = "0.0.0.0"
+		  netmask = 0
+		}
+	}
+	site = data.appgatesdp_site.default_site.id
+	networking {
+		nics {
+		enabled = true
+		name    = "eth0"
+		ipv4 {
+			dhcp {
+			enabled = true
+			dns     = true
+			routers = true
+			ntp     = true
+			}
+		  }
+		}
+	}
+	}
+`, context)
+}

--- a/appgate/resource_appgate_criteria_script_test.go
+++ b/appgate/resource_appgate_criteria_script_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestAccCriteriaScriptBasic(t *testing.T) {
 	resourceName := "appgatesdp_criteria_script.test_criteria_script"
-	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	// Must always start with a letter.
+	rName := "aa" + RandStringFromCharSet(10, CharSetAlphaNum)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,


### PR DESCRIPTION
Correctly remove admin_interface if has been removed from the state, dont sent empty json stub of admin_interface if it has been removed, This PR solved issue #153 


Acceptance test on 5.3.2-23587-release


<details>

```

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
=== RUN   TestConfigGetToken/test_5.4_login
=== RUN   TestConfigGetToken/invalid_client_version
--- PASS: TestConfigGetToken (0.00s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (11.95s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.17s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.18s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.61s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.37s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.79s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.02s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.59s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.90s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.02s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccPolicyBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.2-0
--- SKIP: TestAccGlobalSettings54ProfileHostname (1.85s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.35s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccAdminMfaSettingsBasic (8.43s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccRingfenceRuleBasicICMP (8.86s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccMfaProviderBasic (8.89s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccPolicyBasic (8.91s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccRingfenceRuleBasicTCP (9.29s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccGlobalSettingsBasic (9.80s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccLocalUserBasic (10.04s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccTrustedCertificateBasic (10.06s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccIPPoolBasic (10.20s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (10.74s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccLdapIdentityProviderBasic (11.31s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2171: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.49s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccEntitlementBasicPing (11.61s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccRadiusIdentityProviderBasic (12.28s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (12.49s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.36s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccDeviceScriptBasic (7.55s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccEntitlementScriptBasic (8.10s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccBlacklistUserBasic (6.85s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccCriteriaScriptBasic (7.99s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccConditionBasic (8.77s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccApplianceBasicGateway (11.27s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.33s)
--- PASS: TestAccEntitlementUpdateActionOrder (19.64s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (20.11s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (18.58s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (10.48s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.12s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.42s)
--- PASS: TestAccApplianceConnector (9.85s)
--- PASS: TestAccAppgateMfaProviderDataSource (5.52s)
--- PASS: TestAccadministrativeRoleBasic (5.99s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.22s)
--- PASS: TestAccApplianceCustomizationBasic (10.94s)
--- PASS: TestAccSiteBasic (23.61s)
--- PASS: TestAccadministrativeRoleWithScope (7.51s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (14.82s)
--- PASS: TestAccSamlIdentityProviderBasic (27.64s)
--- PASS: TestAccEntitlementBasicWithMonitor (11.32s)
--- PASS: TestAccApplianceBasicController (18.09s)
--- PASS: TestAccClientProfileBasic (34.28s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	92.195s

```

</details>


Acceptance test on 5.4.1-25150-release
<details>


```
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
=== RUN   TestConfigGetToken/test_5.4_login
=== RUN   TestConfigGetToken/invalid_client_version
--- PASS: TestConfigGetToken (0.00s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.00s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.93s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.01s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.48s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.49s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.80s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.76s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
=== PAUSE TestAccApplianceBasicController
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.57s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
=== PAUSE TestAccGlobalSettingsBasic
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.74s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.69s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccGlobalSettingsBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccApplianceConnector
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccIPPoolBasic (7.59s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccLocalUserBasic (8.24s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.29s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.30s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccMfaProviderBasic (8.58s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccTrustedCertificateBasic (8.81s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccPolicyBasic (8.95s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccGlobalSettings54ProfileHostname (9.00s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccAdminMfaSettingsBasic (9.12s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccRingfenceRuleBasicTCP (9.13s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccGlobalSettingsBasic (9.16s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccRingfenceRuleBasicICMP (9.56s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccApplianceConnector (10.09s)
=== CONT  TestAccApplianceBasicController
--- PASS: TestAccLdapIdentityProviderBasic (10.19s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccEntitlementBasicPing (10.58s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccRadiusIdentityProviderBasic (11.24s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (11.78s)
=== CONT  TestAccadministrativeRoleWithScope
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.44s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccEntitlementScriptBasic (8.17s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccBlacklistUserBasic (6.96s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccDeviceScriptBasic (7.67s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccConditionBasic (7.69s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccCriteriaScriptBasic (7.93s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccadministrativeRoleBasic (7.22s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (18.85s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.84s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (10.01s)
--- PASS: TestAccApplianceBasicGateway (10.48s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.53s)
--- PASS: TestAccadministrativeRoleWithScope (7.93s)
--- PASS: TestAccSiteBasic (20.80s)
--- PASS: TestAccApplianceCustomizationBasic (10.71s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.14s)
--- PASS: TestAccAppgateMfaProviderDataSource (5.56s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (5.86s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (14.49s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (13.03s)
--- PASS: TestAccSamlIdentityProviderBasic (26.38s)
--- PASS: TestAccEntitlementUpdateActionOrder (12.18s)
--- PASS: TestAccEntitlementBasicWithMonitor (12.17s)
--- PASS: TestAccApplianceBasicController (19.05s)
--- PASS: TestAccClientProfileBasic (49.53s)
--- PASS: TestAccAppliancePortalSetup (53.66s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	107.177s

```

</details>
