### PR TITLE
Retryable login with exponential backoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.6.8
+VERSION=0.6.9
 
 
 build:

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -24,14 +24,15 @@ const (
 
 // Config for appgate provider.
 type Config struct {
-	URL      string `json:"appgate_url,omitempty"`
-	Username string `json:"appgate_username,omitempty"`
-	Password string `json:"appgate_password,omitempty"`
-	Provider string `json:"appgate_provider,omitempty"`
-	Insecure bool   `json:"appgate_insecure,omitempty"`
-	Timeout  int    `json:"appgate_timeout,omitempty"`
-	Debug    bool   `json:"appgate_http_debug,omitempty"`
-	Version  int    `json:"appgate_client_version,omitempty"`
+	URL          string `json:"appgate_url,omitempty"`
+	Username     string `json:"appgate_username,omitempty"`
+	Password     string `json:"appgate_password,omitempty"`
+	Provider     string `json:"appgate_provider,omitempty"`
+	Insecure     bool   `json:"appgate_insecure,omitempty"`
+	Timeout      int    `json:"appgate_timeout,omitempty"`
+	LoginTimeout int    `json:"appgate_login_timeout,omitempty"`
+	Debug        bool   `json:"appgate_http_debug,omitempty"`
+	Version      int    `json:"appgate_client_version,omitempty"`
 }
 
 // Client is the appgate API client.
@@ -140,9 +141,16 @@ var exponentialBackOff = backoff.ExponentialBackOff{
 	RandomizationFactor: 0.5,
 	Multiplier:          1.5,
 	MaxInterval:         30 * time.Second,
-	MaxElapsedTime:      5 * time.Minute,
 	Stop:                backoff.Stop,
 	Clock:               backoff.SystemClock,
+}
+
+func (c *Client) loginTimoutDuration() time.Duration {
+	// This is just intend to be used within unit tests.
+	if c.Config.LoginTimeout > 0 {
+		return time.Duration(c.Config.LoginTimeout) * time.Second
+	}
+	return 5 * time.Minute
 }
 
 func (c *Client) login() (*openapi.LoginResponse, error) {
@@ -159,6 +167,7 @@ func (c *Client) login() (*openapi.LoginResponse, error) {
 	// it might take awhile for the controller to startup and be responsive, so until its up it can return 500, 502, 503
 	// these status code is treated as retryable errors, during exponentialBackOff.MaxElapsedTime window.
 	// we will use this exponential backoff to retry until we get a 200-400 HTTP response from /login
+	exponentialBackOff.MaxElapsedTime = c.loginTimoutDuration()
 	loginResponse := &openapi.LoginResponse{}
 	err := backoff.Retry(func() error {
 		login, response, err := c.API.LoginApi.LoginPost(ctx).LoginRequest(loginOpts).Execute()

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -5,11 +5,13 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v15/openapi"
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-version"
 
 	"github.com/google/uuid"
@@ -133,6 +135,16 @@ func (c *Client) GetToken() (string, error) {
 	return c.Token, nil
 }
 
+var exponentialBackOff = backoff.ExponentialBackOff{
+	InitialInterval:     500 * time.Millisecond,
+	RandomizationFactor: 0.5,
+	Multiplier:          1.5,
+	MaxInterval:         30 * time.Second,
+	MaxElapsedTime:      5 * time.Minute,
+	Stop:                backoff.Stop,
+	Clock:               backoff.SystemClock,
+}
+
 func (c *Client) login() (*openapi.LoginResponse, error) {
 	ctx := context.Background()
 	loginOpts := openapi.LoginRequest{
@@ -142,9 +154,32 @@ func (c *Client) login() (*openapi.LoginResponse, error) {
 		DeviceId:     uuid.New().String(),
 	}
 
-	loginResponse, _, err := c.API.LoginApi.LoginPost(ctx).LoginRequest(loginOpts).Execute()
+	// Since /login is the first request we do, it provide us the earliest check if a controller is up and running
+	// if the appgatesdp provider is combined with, for example  aws_instance where we create the inital controller
+	// it might take awhile for the controller to startup and be responsive, so until its up it can return 500, 502, 503
+	// these status code is treated as retryable errors, during exponentialBackOff.MaxElapsedTime window.
+	// we will use this exponential backoff to retry until we get a 200-400 HTTP response from /login
+	loginResponse := &openapi.LoginResponse{}
+	err := backoff.Retry(func() error {
+		login, response, err := c.API.LoginApi.LoginPost(ctx).LoginRequest(loginOpts).Execute()
+		if response == nil {
+			log.Printf("[DEBUG] Login failed, No response %s", err)
+			return fmt.Errorf("No response from controller %w", err)
+		}
+		if response.StatusCode >= 500 {
+			log.Printf("[DEBUG] Login failed, controller not responding, got HTTP %d", response.StatusCode)
+			return fmt.Errorf("Controller got %w", err)
+		}
+		if err != nil {
+			log.Printf("[DEBUG] Login failed permanently, got HTTP %d", response.StatusCode)
+			return &backoff.PermanentError{Err: err}
+		}
+		loginResponse = &login
+		return nil
+	}, &exponentialBackOff)
 	if err != nil {
 		return nil, prettyPrintAPIError(err)
 	}
-	return &loginResponse, nil
+	log.Printf("[DEBUG] Login OK")
+	return loginResponse, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/appgate/sdp-api-client-go v1.0.3
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/cenkalti/backoff/v4 v4.1.1 h1:G2HAfAmvm/GcKan2oOQpBXOd2tT2G57ZnZGWa1PxPBQ=
+github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
Add support for retryable login, to retry if we get HTTP 5XX response.

Acceptance test on 5.4.1-25150-release
<details>


```bash
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/09/22 09:35:31 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/09/22 09:35:31 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/09/22 09:35:31 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/09/22 09:35:31 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/09/22 09:35:32 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/09/22 09:35:32 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/09/22 09:35:32 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/09/22 09:35:32 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/09/22 09:35:33 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.60s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.58s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.24s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.18s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.05s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.51s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.35s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.59s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.70s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (11.32s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.42s)
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.53s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.77s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.70s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.72s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccPolicyBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.55s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccIPPoolBasic (7.82s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccRingfenceRuleBasicTCP (8.24s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccMfaProviderBasic (8.25s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccTrustedCertificateBasic (8.29s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccCriteriaScriptBasic (8.45s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccPolicyBasic (8.55s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.57s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccAdminMfaSettingsBasic (8.60s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccDeviceScriptBasic (8.68s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccEntitlementScriptBasic (8.87s)
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccGlobalSettings54ProfileHostname (9.02s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccRingfenceRuleBasicICMP (9.12s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.95s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (10.55s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccEntitlementBasicPing (10.84s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccApplianceBasicGateway (10.88s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccRadiusIdentityProviderBasic (11.38s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccLdapIdentityProviderBasic (11.47s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccAppgateApplianceCustomizationDataSource (6.41s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccBlacklistUserBasic (5.99s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.98s)
--- PASS: TestAccConditionBasic (7.01s)
--- PASS: TestAccAppgateMfaProviderDataSource (7.17s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.72s)
--- PASS: TestAccadministrativeRoleBasic (7.63s)
--- PASS: TestAccApplianceConnector (9.23s)
--- PASS: TestAccadministrativeRoleWithScope (8.60s)
--- PASS: TestAccApplianceCustomizationBasic (10.05s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (8.49s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (8.30s)
--- PASS: TestAccSiteBasic (19.39s)
--- PASS: TestAccLocalUserBasic (4.87s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (13.11s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (12.16s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (12.08s)
--- PASS: TestAccEntitlementUpdateActionOrder (12.70s)
--- PASS: TestAccSamlIdentityProviderBasic (25.30s)
--- PASS: TestAccEntitlementBasicWithMonitor (10.83s)
--- PASS: TestAccClientProfileBasic (32.11s)
--- PASS: TestAccAppliancePortalSetup (49.87s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	126.773s

```
</details>




Acceptance test on 5.3.2-23587-release
<details>


```bash
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/09/22 09:40:17 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/09/22 09:40:17 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/09/22 09:40:17 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/09/22 09:40:17 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/09/22 09:40:18 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/09/22 09:40:18 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/09/22 09:40:18 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/09/22 09:40:18 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/09/22 09:40:19 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.60s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.58s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.38s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.85s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.77s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.38s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.45s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.91s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.84s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (11.26s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.35s)
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.70s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.53s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.94s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.82s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccBlacklistUserBasic (7.12s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.31s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.76s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccAppgateMfaProviderDataSource (7.80s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.84s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccConditionBasic (8.30s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccadministrativeRoleBasic (8.33s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccCriteriaScriptBasic (8.52s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccTrustedCertificateBasic (8.79s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.86s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccDeviceScriptBasic (8.99s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccRingfenceRuleBasicTCP (9.52s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccRingfenceRuleBasicICMP (9.65s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccEntitlementScriptBasic (9.67s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccadministrativeRoleWithScope (9.97s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccEntitlementBasicPing (10.06s)
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.2-0
--- SKIP: TestAccGlobalSettings54ProfileHostname (0.92s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.87s)
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.10s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.99s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccAdminMfaSettingsBasic (6.29s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.12s)
--- PASS: TestAccLocalUserBasic (7.15s)
--- PASS: TestAccIPPoolBasic (7.13s)
--- PASS: TestAccMfaProviderBasic (7.68s)
--- PASS: TestAccPolicyBasic (7.87s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (16.19s)
--- PASS: TestAccLdapIdentityProviderBasic (9.77s)
--- PASS: TestAccApplianceBasicGateway (8.47s)
--- PASS: TestAccRadiusIdentityProviderBasic (8.77s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (8.10s)
--- PASS: TestAccApplianceConnector (8.92s)
--- PASS: TestAccSiteBasic (19.53s)
--- PASS: TestAccApplianceCustomizationBasic (8.42s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (6.65s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (12.85s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (12.45s)
--- PASS: TestAccEntitlementBasicWithMonitor (11.85s)
--- PASS: TestAccEntitlementUpdateActionOrder (11.74s)
--- PASS: TestAccClientProfileBasic (27.11s)
--- PASS: TestAccSamlIdentityProviderBasic (19.03s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	97.395s

```
</details>