### PR TITLE
Issue/165 tags

### DIFF
--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -131,6 +131,44 @@ func TestAccSiteBasic(t *testing.T) {
 				ImportState:      true,
 				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
 			},
+			{
+				Config: testAccCheckSiteTagsDelete(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckSiteTagsAdd(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "qwerty"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckSiteTagsDelete(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "0"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
 		},
 	})
 }
@@ -333,6 +371,147 @@ resource "appgatesdp_site" "test_site" {
         "api-created",
     	"updated-tag"
     ]
+    notes = "This object has been created for test purposes."
+    entitlement_based_routing = false
+    network_subnets = [
+        "10.20.0.0/24"
+    ]
+
+    default_gateway {
+        enabled_v4       = false
+        enabled_v6       = false
+        excluded_subnets = []
+    }
+
+    name_resolution {
+        dns_resolvers {
+            name            = "DNS Resolver 1"
+            update_interval = 13
+            servers = [
+                "8.8.8.8",
+                "1.1.1.1"
+            ]
+            search_domains = [
+                "hostname.dns",
+                "foo.bar"
+            ]
+        }
+
+        aws_resolvers {
+            name = "AWS Resolver 1"
+            update_interval    = 59
+            vpcs               = ["test"]
+            vpc_auto_discovery = true
+            use_iam_role       = true
+            access_key_id      = "string1"
+            secret_access_key  = "string2"
+            resolve_with_master_credentials = true
+        }
+
+        azure_resolvers {
+            name            = "Azure Resolver 1"
+            update_interval = 30
+            subscription_id = "string1"
+            tenant_id       = "string2"
+            client_id       = "string3"
+            secret          = "string4"
+        }
+
+        esx_resolvers {
+            name            = "ESX Resolver 1"
+            update_interval = 120
+            hostname        = "string1"
+            username        = "string2"
+            password        = "secret_password"
+        }
+
+        gcp_resolvers {
+            name            = "GCP Resolver 1"
+            update_interval = 360
+            project_filter  = "string1"
+            instance_filter = "string2"
+        }
+    }
+}
+`
+}
+
+func testAccCheckSiteTagsDelete() string {
+	return `
+resource "appgatesdp_site" "test_site" {
+    name       = "The test site"
+    short_name = "tst"
+    notes = "This object has been created for test purposes."
+    entitlement_based_routing = false
+    network_subnets = [
+        "10.20.0.0/24"
+    ]
+
+    default_gateway {
+        enabled_v4       = false
+        enabled_v6       = false
+        excluded_subnets = []
+    }
+
+    name_resolution {
+        dns_resolvers {
+            name            = "DNS Resolver 1"
+            update_interval = 13
+            servers = [
+                "8.8.8.8",
+                "1.1.1.1"
+            ]
+            search_domains = [
+                "hostname.dns",
+                "foo.bar"
+            ]
+        }
+
+        aws_resolvers {
+            name = "AWS Resolver 1"
+            update_interval    = 59
+            vpcs               = ["test"]
+            vpc_auto_discovery = true
+            use_iam_role       = true
+            access_key_id      = "string1"
+            secret_access_key  = "string2"
+            resolve_with_master_credentials = true
+        }
+
+        azure_resolvers {
+            name            = "Azure Resolver 1"
+            update_interval = 30
+            subscription_id = "string1"
+            tenant_id       = "string2"
+            client_id       = "string3"
+            secret          = "string4"
+        }
+
+        esx_resolvers {
+            name            = "ESX Resolver 1"
+            update_interval = 120
+            hostname        = "string1"
+            username        = "string2"
+            password        = "secret_password"
+        }
+
+        gcp_resolvers {
+            name            = "GCP Resolver 1"
+            update_interval = 360
+            project_filter  = "string1"
+            instance_filter = "string2"
+        }
+    }
+}
+`
+}
+
+func testAccCheckSiteTagsAdd() string {
+	return `
+resource "appgatesdp_site" "test_site" {
+    name       = "The test site"
+    short_name = "tst"
+	tags = ["qwerty"]
     notes = "This object has been created for test purposes."
     entitlement_based_routing = false
     network_subnets = [

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -62,7 +62,6 @@ func tagsSchema() *schema.Schema {
 		StateFunc: func(val interface{}) string {
 			return strings.ToLower(val.(string))
 		},
-		DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
 		Set: func(v interface{}) int {
 			var buf bytes.Buffer
 			str := v.(string)


### PR DESCRIPTION
This PR should fix issues reported in #165 

Acceptance tests for 5.3.2-23587-release

<details>



```bash

make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/10/04 13:35:02 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/10/04 13:35:02 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/10/04 13:35:02 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/10/04 13:35:02 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/10/04 13:35:02 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/10/04 13:35:02 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/10/04 13:35:03 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/10/04 13:35:03 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/10/04 13:35:03 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.60s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.58s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.01s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.12s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.36s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.91s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.64s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.90s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.23s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.95s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.81s)
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.10s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.64s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.04s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.65s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccConditionBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccApplianceConnector
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.4 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccAppliancePortalSetup (1.67s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccBlacklistUserBasic (7.40s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.94s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccConditionBasic (8.18s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccAppgateTrustedCertificateDataSource (8.23s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccAppgateMfaProviderDataSource (6.83s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccDeviceScriptBasic (8.97s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccTrustedCertificateBasic (8.99s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccCriteriaScriptBasic (9.31s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccEntitlementScriptBasic (9.68s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccApplianceBasicGateway (10.46s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccEntitlementBasicPing (11.08s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccApplianceConnector (11.52s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (11.55s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (11.81s)
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.2-0
--- SKIP: TestAccGlobalSettings54ProfileHostname (1.04s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccApplianceCustomizationBasic (14.36s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccAppgateApplianceCustomizationDataSource (7.64s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccAdminMfaSettingsBasic (8.62s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccRingfenceRuleBasicICMP (9.01s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.94s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccLocalUserBasic (10.23s)
--- PASS: TestAccPolicyBasic (9.21s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccRingfenceRuleBasicTCP (9.95s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (18.47s)
--- PASS: TestAccMfaProviderBasic (8.82s)
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.65s)
--- PASS: TestAccEntitlementBasicWithMonitor (18.72s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (19.34s)
--- PASS: TestAccIPPoolBasic (8.46s)
--- PASS: TestAccEntitlementUpdateActionOrder (19.61s)
--- PASS: TestAccLdapIdentityProviderBasic (9.29s)
--- PASS: TestAccRadiusIdentityProviderBasic (9.29s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (8.26s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (6.43s)
--- PASS: TestAccadministrativeRoleBasic (4.22s)
--- PASS: TestAccadministrativeRoleWithScope (5.93s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (11.38s)
--- PASS: TestAccSamlIdentityProviderBasic (20.02s)
--- PASS: TestAccSiteBasic (24.51s)
--- PASS: TestAccClientProfileBasic (42.02s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	116.025s

``` 


</details>



Acceptance test for 5.4.3-26106-release


<details>


```bash

 make testacc          
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/10/04 13:25:21 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/10/04 13:25:21 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/10/04 13:25:21 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/10/04 13:25:21 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/10/04 13:25:22 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/10/04 13:25:22 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/10/04 13:25:23 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/10/04 13:25:23 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/10/04 13:25:23 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.61s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.59s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.37s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.91s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.21s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.53s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.49s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.72s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.62s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (11.52s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.96s)
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.47s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.71s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.81s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.72s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccConditionBasic
=== CONT  TestAccApplianceConnector
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccBlacklistUserBasic (6.94s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccAppgateMfaProviderDataSource (7.32s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.44s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.57s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccIPPoolBasic (7.65s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccTrustedCertificateBasic (7.78s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccDeviceScriptBasic (7.99s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccCriteriaScriptBasic (8.01s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.34s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccConditionBasic (8.70s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccEntitlementScriptBasic (8.72s)
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.21s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicPing (10.15s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccApplianceBasicGateway (10.17s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccApplianceConnector (10.55s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (10.59s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.85s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccApplianceCustomizationBasic (12.36s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccAdminMfaSettingsBasic (6.54s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccRingfenceRuleBasicTCP (7.42s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccPolicyBasic (7.22s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccRingfenceRuleBasicICMP (7.40s)
--- PASS: TestAccMfaProviderBasic (7.23s)
--- PASS: TestAccLocalUserBasic (7.09s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.57s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.31s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (15.48s)
--- PASS: TestAccadministrativeRoleWithScope (7.96s)
--- PASS: TestAccLdapIdentityProviderBasic (7.34s)
--- PASS: TestAccRadiusIdentityProviderBasic (8.53s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (7.84s)
--- PASS: TestAccGlobalSettings54ProfileHostname (5.14s)
--- PASS: TestAccadministrativeRoleBasic (4.54s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (12.75s)
--- PASS: TestAccEntitlementUpdateActionOrder (12.90s)
--- PASS: TestAccEntitlementBasicWithMonitor (11.66s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (10.48s)
--- PASS: TestAccSamlIdentityProviderBasic (20.31s)
--- PASS: TestAccSiteBasic (23.31s)
--- PASS: TestAccAppliancePortalSetup (38.53s)
--- PASS: TestAccClientProfileBasic (45.15s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	112.853s

``` 


</details>