### PR TITLE
appgate_condition: expose condition_id as attribute

### DIFF
--- a/appgate/data_source_appgate_condition.go
+++ b/appgate/data_source_appgate_condition.go
@@ -52,6 +52,7 @@ func dataSourceAppgateConditionRead(d *schema.ResourceData, meta interface{}) er
 	}
 
 	d.SetId(condition.Id)
+	d.Set("condition_id", condition.Id)
 	d.Set("condition_name", condition.Name)
 
 	return nil


### PR DESCRIPTION
I came across this data source which does not expose argument condition_id as an attribute which is supposed to be used by other resource which leaves developers to use `.id` which is terraform id 

this also matches with other data sources example https://github.com/appgate/terraform-provider-appgatesdp/blob/master/appgate/data_source_appgate_site.go#L86

```
│ Error: Null value found in list
│
│   with appgatesdp_entitlement.map["ssh"],
│   on appgate.tf line 382, in resource "appgatesdp_entitlement" "map":
│  382:   conditions = [
│  383:     data.appgatesdp_condition.check_falcon.condition_id,
│  384:   ]
│
│ Null values are not allowed for this attribute value.
```