### PR TITLE
updated documentation for appliance peer_interface

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -160,10 +160,14 @@ func resourceAppgateAppliance() *schema.Resource {
 			},
 
 			"peer_interface": {
-				Type:       schema.TypeList,
-				Required:   true,
-				Deprecated: "peer_interface is deprecated as of 5.4. All connections will be handled by clientInterface and adminInterface in the future. The hostname field is used as identifier and will take over the hostname field in the root of Appliance when this interface is removed.",
-				MaxItems:   1,
+				Type:     schema.TypeList,
+				Required: true,
+				// TODO:
+				// Temporary removed this warning, since its not scheduled to be removed until the version after 5.5
+				// and since its still required for all existing supported versions, we will not show this error for the users.
+				//
+				// Deprecated: "peer_interface is deprecated as of 5.4. All connections will be handled by clientInterface and adminInterface in the future. The hostname field is used as identifier and will take over the hostname field in the root of Appliance when this interface is removed.",
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"hostname": {

--- a/website/docs/r/appliance.markdown
+++ b/website/docs/r/appliance.markdown
@@ -309,6 +309,9 @@ Source configuration to allow via iptables.
 ### peer_interface
 The details of peer connection interface. Used by other appliances and administrative UI.
 
+!> **Warning:** peer_interface will be removed in future release. Estimated to be removed in the release after 5.5
+
+
 * `hostname`: (Required) Hostname to connect by the peers. It will be used to validate the appliance certificate. Example: appgate.company.com.
 * `https_port`:  (Optional)  default value `444` Port to connect for peer specific services.
 * `allow_sources`:  (Optional) Source configuration to allow via iptables.


### PR DESCRIPTION
Suppress `appliance.peer_interface` warning about deprecation since it wont be removed until 1-2 versions from now, will re-introduce it again in the future. Since this field is still required on all supported versions we wont show this warning until its needed.

Example of warning
```bash
│ Warning: Argument is deprecated
│ 
│   with appgatesdp_appliance.template_gateway,
│   on main.tf line 28, in resource "appgatesdp_appliance" "template_gateway":
│   28: resource "appgatesdp_appliance" "template_gateway" {
│ 
│ peer_interface is deprecated as of 5.4. All connections will be handled by clientInterface and adminInterface in the future. The hostname field is used as identifier and will take over the hostname field in the root of Appliance when this interface is removed.
│ 
│ (and 3 more similar warnings elsewhere)
╵
```