### PR TITLE
V16 appliance elasticsearch compatibility_mode, authentication

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -713,7 +713,7 @@ func resourceAppgateAppliance() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"url": {
 										Type:     schema.TypeString,
-										Optional: true,
+										Required: true,
 									},
 									"aws_id": {
 										Type:     schema.TypeString,
@@ -750,8 +750,9 @@ func resourceAppgateAppliance() *schema.Resource {
 													Required: true,
 												},
 												"token": {
-													Type:     schema.TypeString,
-													Required: true,
+													Type:      schema.TypeString,
+													Required:  true,
+													Sensitive: true,
 												},
 											},
 										},
@@ -1271,7 +1272,7 @@ func resourceAppgateApplianceCreate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if v, ok := d.GetOk("log_forwarder"); ok {
-		lf, err := readLogForwardFromConfig(v.([]interface{}))
+		lf, err := readLogForwardFromConfig(v.([]interface{}), currentVersion)
 		if err != nil {
 			return err
 		}
@@ -1704,7 +1705,7 @@ func resourceAppgateApplianceRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := appliance.GetLogForwarderOk(); ok {
-		logforward, err := flatttenApplianceLogForwarder(*v)
+		logforward, err := flatttenApplianceLogForwarder(*v, currentVersion, d)
 		if err != nil {
 			return err
 		}
@@ -1871,7 +1872,7 @@ func flatttenApplianceGateway(in openapi.ApplianceAllOfGateway) ([]map[string]in
 	return gateways, nil
 }
 
-func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder) ([]map[string]interface{}, error) {
+func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder, currentVersion *version.Version, d *schema.ResourceData) ([]map[string]interface{}, error) {
 	var logforwarders []map[string]interface{}
 	logforward := make(map[string]interface{})
 	if v, ok := in.GetEnabledOk(); ok {
@@ -1897,6 +1898,29 @@ func flatttenApplianceLogForwarder(in openapi.ApplianceAllOfLogForwarder) ([]map
 		}
 		if v, ok := v.GetRetentionDaysOk(); ok {
 			elasticsearch["retention_days"] = *v
+		}
+		if currentVersion.GreaterThanOrEqual(Appliance55Version) {
+			if v, ok := v.GetCompatibilityModeOk(); ok {
+				elasticsearch["compatibility_mode"] = *v
+			}
+			if authRaw, ok := v.GetAuthenticationOk(); ok {
+				auth := make(map[string]interface{})
+				if v, ok := authRaw.GetTypeOk(); ok {
+					auth["type"] = v
+				}
+
+				// token is sensitive, so we wont get it in the response body, but we can lookup it from the state
+				if state := d.Get("log_forwarder.0.elasticsearch.0.authentication").([]interface{}); len(state) > 0 && state[0] != nil {
+					s := state[0].(map[string]interface{})
+					if v, ok := s["token"]; ok {
+						auth["token"] = v.(string)
+					}
+				} else if v, ok := authRaw.GetTokenOk(); ok {
+					log.Printf("[DEBUG] Could not find log_forwarder.0.elasticsearch.0.authentication.token in state, fallback to API response")
+					auth["token"] = v
+				}
+				elasticsearch["authentication"] = []map[string]interface{}{auth}
+			}
 		}
 		logforward["elasticsearch"] = []map[string]interface{}{elasticsearch}
 	}
@@ -2377,7 +2401,7 @@ func resourceAppgateApplianceUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("log_forwarder") {
 		_, v := d.GetChange("log_forwarder")
-		lf, err := readLogForwardFromConfig(v.([]interface{}))
+		lf, err := readLogForwardFromConfig(v.([]interface{}), currentVersion)
 		if err != nil {
 			return err
 		}
@@ -2848,7 +2872,7 @@ func readPingFromConfig(pingers []interface{}) (openapi.ApplianceAllOfPing, erro
 	return val, nil
 }
 
-func readLogForwardFromConfig(logforwards []interface{}) (openapi.ApplianceAllOfLogForwarder, error) {
+func readLogForwardFromConfig(logforwards []interface{}, currentVersion *version.Version) (openapi.ApplianceAllOfLogForwarder, error) {
 	val := openapi.ApplianceAllOfLogForwarder{}
 	for _, logforward := range logforwards {
 		if logforward == nil {
@@ -2883,6 +2907,30 @@ func readLogForwardFromConfig(logforwards []interface{}) (openapi.ApplianceAllOf
 				if v, ok := r["retention_days"]; ok {
 					elasticsearch.SetRetentionDays(int32(v.(int)))
 				}
+				if v, ok := r["compatibility_mode"]; ok {
+					if currentVersion.LessThan(Appliance55Version) {
+						return val, fmt.Errorf("elasticsearch.compatibility_mode is only available in 5.5 or greater, got %s", currentVersion)
+					}
+					elasticsearch.SetCompatibilityMode(int32(v.(int)))
+				}
+
+				if v, ok := r["authentication"].([]interface{}); ok {
+					if currentVersion.LessThan(Appliance55Version) {
+						return val, fmt.Errorf("elasticsearch.authentication is only available in 5.5 or greater, got %s", currentVersion)
+					}
+					val := v[0].(map[string]interface{})
+					a := openapi.ElasticsearchAllOfAuthentication{}
+					if v, ok := val["type"].(string); ok && len(v) > 0 {
+						a.SetType(v)
+					}
+					if v, ok := val["token"].(string); ok && len(v) > 0 {
+						a.SetToken(v)
+					}
+					if len(a.GetType()) > 0 {
+						elasticsearch.SetAuthentication(a)
+					}
+				}
+
 			}
 			val.SetElasticsearch(elasticsearch)
 		}

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -2987,3 +2987,449 @@ resource "appgatesdp_appliance" "log_server" {
 }
 `, context)
 }
+
+func TestAccApplianceLogForwarderElastic55(t *testing.T) {
+	resourceName := "appgatesdp_appliance.log_forwarder_elasticsearch"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":     rName,
+		"hostname": fmt.Sprintf("%s.devops", rName),
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApplianceDestroy,
+
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
+					if currentVersion.LessThan(Appliance55Version) {
+						t.Skip("Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase")
+					}
+				},
+				Config: testAccCheckApplianceLogforwarderElasticSearch(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "445"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "444"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "true"),
+					resource.TestCheckResourceAttr(resourceName, "connect_to_peers_using_client_port_with_spa", "true"),
+					resource.TestCheckResourceAttr(resourceName, "connector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.advanced_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.express_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "customization", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.port", "5555"),
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "hostname_aliases.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.aws_kineses.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.authentication.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.authentication.0.token", "user:password"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.authentication.0.type", "ServiceAccounts"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.aws_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.aws_region", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.aws_secret", ""),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.compatibility_mode", "10"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.retention_days", "90"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.url", "https://aws.com/elasticsearch/instance/asdaxllkmda64"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.0.use_instance_credentials", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sites.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sites.0", "8a4add9e-0e99-4bb1-949c-c9faf9a49ad4"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.tcp_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.dns_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.dns_domains.0", "aa.com"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.dns_servers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.dns_servers.1", "8.8.8.8"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.0.hostname", "bla"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.address", "10.10.10.1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.hostname", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.snat", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.1.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.1.address", "20.20.20.1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.1.hostname", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.1.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.1.snat", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.mtu", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.0.dns", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.dhcp.0.routers", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv4.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.dhcp.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.ipv6.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.mtu", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.1.name", "eth1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.0.gateway", "1.2.3.4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.hostname", "0.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.hostname", "1.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.hostname", "2.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.hostname", "3.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.0.https_port", "1337"),
+					resource.TestCheckResourceAttr(resourceName, "ping.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.external_profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.https_p12.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.proxy_p12s.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.port", "1234"),
+					resource.TestCheckResourceAttr(resourceName, "rsyslog_destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "site", ""),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.snmpd_conf", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.tcp_port", "161"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.udp_port", "161"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.nic", "eth1"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.password_authentication", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.port", "2222"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-test-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateCheck:        testAccApplianceImportStateCheckFunc(1),
+				ImportStateVerifyIgnore: []string{"site", "seed_file", "log_forwarder.0.elasticsearch.0.authentication.0.token"}, // we cant import verify local file path
+
+			},
+		},
+	})
+}
+
+func testAccCheckApplianceLogforwarderElasticSearch(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+
+resource "appgatesdp_appliance" "log_forwarder_elasticsearch" {
+	name                                        = "%{name}"
+	hostname                                    = "%{hostname}"
+	connect_to_peers_using_client_port_with_spa = true
+	client_interface {
+		hostname       = "%{hostname}"
+		proxy_protocol = true
+		https_port     = 444
+		dtls_port      = 445
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+		override_spa_mode = "TCP"
+	}
+	peer_interface {
+		hostname   = "%{hostname}"
+		https_port = "1337"
+	}
+	tags = [
+		"terraform",
+		"api-test-created"
+	]
+	ntp {
+		servers {
+			hostname = "0.ubuntu.pool.ntp.org"
+		}
+		servers {
+			hostname = "1.ubuntu.pool.ntp.org"
+		}
+		servers {
+			hostname = "2.ubuntu.pool.ntp.org"
+		}
+		servers {
+			hostname = "3.ubuntu.pool.ntp.org"
+		}
+	}
+	networking {
+
+		hosts {
+			hostname = "bla"
+			address  = "0.0.0.0"
+		}
+
+		nics {
+		enabled = true
+		name    = "eth0"
+
+		ipv4 {
+			dhcp {
+			enabled = false
+			dns     = true
+			routers = true
+			ntp     = true
+			}
+
+			static {
+			address = "10.10.10.1"
+			netmask = 24
+			snat    = true
+			}
+
+			static {
+			address = "20.20.20.1"
+			netmask = 32
+			snat    = false
+			}
+		}
+		ipv6 {
+			dhcp {
+				enabled = false
+				dns     = true
+				ntp     = false
+			}
+		}
+
+	}
+
+		nics {
+		enabled = true
+		name    = "eth1"
+		ipv4 {
+			dhcp {
+				enabled = true
+				dns     = false
+				routers = false
+				ntp     = false
+			}
+		}
+		ipv6 {
+				dhcp {
+					enabled = false
+					dns     = true
+					ntp     = false
+				}
+			}
+		}
+
+		dns_servers = [
+			"8.8.8.8",
+			"1.1.1.1",
+		]
+		dns_domains = [
+			"aa.com"
+		]
+		routes {
+			address = "0.0.0.0"
+			netmask = 24
+			gateway = "1.2.3.4"
+			nic     = "eth0"
+		}
+	}
+	controller {
+		enabled = false
+	}
+	snmp_server {
+		enabled    = true
+		tcp_port   = 161
+		udp_port   = 161
+		snmpd_conf = "foo"
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+	}
+	ssh_server {
+		enabled                 = true
+		port                    = 2222
+		password_authentication = true
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+		allow_sources {
+			address = "0.0.0.0"
+			netmask = 32
+			nic     = "eth1"
+		}
+	}
+	prometheus_exporter {
+		enabled = true
+		port    = 1234
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+	}
+	healthcheck_server {
+			enabled = true
+			port    = 5555
+			allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+	}
+
+	ping {
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+	}
+	log_forwarder {
+		enabled = true
+		elasticsearch {
+			retention_days     = 90
+			compatibility_mode = 10
+			url                = "https://aws.com/elasticsearch/instance/asdaxllkmda64"
+			authentication {
+					type  = "ServiceAccounts"
+					token = "user:password"
+				}
+		}
+		sites = [
+			data.appgatesdp_site.default_site.id
+		]
+	}
+}
+`, context)
+}


### PR DESCRIPTION
added compatibility_mode, authentication attributes to `appliance.log_forwarder_elasticseach`


Acceptance test for 5.3.2-23587-release

<details>

```

make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/10/25 09:31:15 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/10/25 09:31:15 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/10/25 09:31:15 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/10/25 09:31:15 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/10/25 09:31:15 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/10/25 09:31:15 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/10/25 09:31:16 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/10/25 09:31:16 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/10/25 09:31:16 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.61s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.58s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (8.84s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.10s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.86s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.31s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.83s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.77s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.20s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.97s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.71s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.71s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.79s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.84s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.04s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.91s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccSiteBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceConnector
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.45s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.51s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.50s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccEntitlementScriptBasic (7.73s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.63s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.49s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccIPPoolBasic (9.42s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccTrustedCertificateBasic (9.74s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccRingfenceRuleBasicICMP (10.02s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (10.06s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccRingfenceRuleBasicTCP (10.13s)
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.0+estimated
--- PASS: TestAccDeviceScriptBasic (10.17s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccPolicyBasic (10.49s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- SKIP: TestAccGlobalSettings54ProfileHostname (1.32s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicPing (11.73s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccApplianceBasicGateway (12.00s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccApplianceConnector (12.66s)
=== CONT  TestAccConditionBasic
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3010: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (12.82s)
=== CONT  TestAccClientProfileBasic
--- PASS: TestAccRadiusIdentityProviderBasic (11.68s)
=== CONT  TestAccBlacklistUserBasic
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.42s)
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccLdapIdentityProviderBasic (11.47s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- SKIP: TestAccAppliancePortalSetup (1.47s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccApplianceCustomizationBasic (14.79s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.93s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.88s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccAppgateMfaProviderDataSource (7.67s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccAppgateApplianceCustomizationDataSource (8.25s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccadministrativeRoleBasic (9.49s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (9.87s)
--- PASS: TestAccEntitlementUpdateActionOrder (20.36s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (11.84s)
--- PASS: TestAccEntitlementBasicWithMonitor (20.66s)
--- PASS: TestAccBlacklistUserBasic (7.62s)
--- PASS: TestAccadministrativeRoleWithScope (10.80s)
--- PASS: TestAccCriteriaScriptBasic (8.90s)
--- PASS: TestAccConditionBasic (8.74s)
--- PASS: TestAccMfaProviderBasic (7.16s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (8.69s)
--- PASS: TestAccAdminMfaSettingsBasic (5.92s)
--- PASS: TestAccIPPoolV6 (5.49s)
--- PASS: TestAccLocalUserBasic (6.12s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (15.20s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (14.92s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (12.26s)
--- PASS: TestAccSamlIdentityProviderBasic (27.87s)
--- PASS: TestAccSiteBasic (30.76s)
--- PASS: TestAccClientProfileBasic (36.71s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	125.053s

```

</details>


Acceptance test for 5.4.2-25749-release

<details>

```
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/10/25 09:19:56 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/10/25 09:19:56 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/10/25 09:19:56 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/10/25 09:19:56 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/10/25 09:19:57 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/10/25 09:19:57 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/10/25 09:19:57 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/10/25 09:19:57 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/10/25 09:19:58 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.61s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.59s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (12.35s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.40s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.64s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.38s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.89s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.67s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.05s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.05s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.60s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (9.13s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.93s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (3.04s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.62s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.38s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccConditionBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.41s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.45s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.48s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.48s)
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3010: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.11s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.63s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccConditionBasic (9.48s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccCriteriaScriptBasic (9.71s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccTrustedCertificateBasic (9.71s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccIPPoolBasic (9.75s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccDeviceScriptBasic (10.04s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccEntitlementScriptBasic (10.10s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccGlobalSettings54ProfileHostname (10.35s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccBlacklistUserBasic (8.00s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccEntitlementBasicPing (11.24s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (12.01s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (12.41s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccLdapIdentityProviderBasic (12.56s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccRadiusIdentityProviderBasic (12.64s)
=== CONT  TestAccApplianceBasicGateway
--- SKIP: TestAccAppliancePortalSetup (1.54s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccPolicyBasic (10.02s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.89s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccRingfenceRuleBasicTCP (9.48s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccAdminMfaSettingsBasic (8.87s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccRingfenceRuleBasicICMP (9.49s)
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccMfaProviderBasic (9.46s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccLocalUserBasic (9.00s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.27s)
--- PASS: TestAccClientProfileBasic (19.25s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.69s)
--- PASS: TestAccEntitlementBasicWithMonitor (21.51s)
--- PASS: TestAccEntitlementUpdateActionOrder (21.57s)
--- PASS: TestAccIPPoolV6 (9.59s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (20.54s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (20.89s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (10.00s)
--- PASS: TestAccApplianceConnector (10.35s)
--- PASS: TestAccApplianceBasicGateway (10.98s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (5.61s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.42s)
--- PASS: TestAccAppgateMfaProviderDataSource (5.51s)
--- PASS: TestAccadministrativeRoleBasic (5.84s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (15.56s)
--- PASS: TestAccApplianceCustomizationBasic (8.80s)
--- PASS: TestAccadministrativeRoleWithScope (7.27s)
--- PASS: TestAccSamlIdentityProviderBasic (28.86s)
--- PASS: TestAccSiteBasic (25.82s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	116.295s

```

</details>

Acceptance test for 5.5.0-26218-release

<details>

```

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/10/25 09:26:58 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/10/25 09:26:58 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
2021/10/25 09:26:58 [DEBUG] Login OK
=== RUN   TestConfigGetToken/500_login_response
2021/10/25 09:26:58 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/10/25 09:26:58 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/10/25 09:26:58 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/10/25 09:26:59 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/10/25 09:26:59 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/10/25 09:26:59 [DEBUG] Login failed, controller not responding, got HTTP 503
--- PASS: TestConfigGetToken (1.60s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.58s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (8.26s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.97s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.50s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.68s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.39s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.54s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.74s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.11s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.03s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.64s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.85s)
=== RUN   TestAccClientProfileBasic
=== PAUSE TestAccClientProfileBasic
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.85s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.09s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.21s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccClientProfileBasic
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccApplianceLogForwarderElastic55
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic (1.32s)
=== CONT  TestAccAppliancePortalSetup
--- SKIP: TestAccRadiusIdentityProviderBasic (1.34s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- SKIP: TestAccSamlIdentityProviderBasic (1.46s)
=== CONT  TestAccTrustedCertificateBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.59s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccBlacklistUserBasic (7.92s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccEntitlementScriptBasic (8.53s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccCriteriaScriptBasic (8.58s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccConditionBasic (9.06s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccIPPoolBasic (9.40s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccDeviceScriptBasic (9.70s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccRingfenceRuleBasicICMP (8.91s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccTrustedCertificateBasic (8.94s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccEntitlementBasicPing (11.01s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (11.46s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (11.57s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (11.61s)
=== CONT  TestAccMfaProviderBasic
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.31s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (11.77s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccApplianceLogForwarderElastic55 (11.94s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.30s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccRingfenceRuleBasicTCP (8.29s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.35s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccApplianceAdminInterfaceAddRemove (17.69s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.12s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
--- PASS: TestAccEntitlementUpdateActionOrder (18.56s)
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccAppgateMfaProviderDataSource (7.05s)
=== CONT  TestAccIPPoolV6
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (1.42s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccApplianceBasicGateway (10.07s)
--- PASS: TestAccEntitlementBasicWithMonitor (19.49s)
--- PASS: TestAccadministrativeRoleBasic (8.27s)
--- PASS: TestAccAdminMfaSettingsBasic (8.55s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (11.30s)
--- PASS: TestAccPolicyBasic (8.75s)
--- PASS: TestAccApplianceConnector (10.98s)
--- PASS: TestAccMfaProviderBasic (9.14s)
--- PASS: TestAccadministrativeRoleWithScope (9.96s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (6.07s)
--- PASS: TestAccApplianceCustomizationBasic (12.11s)
--- PASS: TestAccGlobalSettings54ProfileHostname (6.25s)
--- PASS: TestAccIPPoolV6 (4.52s)
--- PASS: TestAccLocalUserBasic (5.13s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (8.15s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (10.68s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (10.42s)
--- PASS: TestAccSiteBasic (24.96s)
--- PASS: TestAccAppliancePortalSetup (51.96s)
--- PASS: TestAccClientProfileBasic (54.13s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	126.624s


```

</details>