### PR TITLE
bump sdp-api-client-go from v1.0.4 to v1.0.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.4-0.20211018123838-9733ee5d6df9
+	github.com/appgate/sdp-api-client-go v1.0.5
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/appgate/sdp-api-client-go v1.0.4-0.20211018123838-9733ee5d6df9 h1:hlToeEicL8wuwo8LDySvVPHllIDrzhGq1PgDigNXUU0=
-github.com/appgate/sdp-api-client-go v1.0.4-0.20211018123838-9733ee5d6df9/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.5 h1:SeOQmS31ygVtm0jv2EEvyP9kaCmsDbY/7rimA1ML72A=
+github.com/appgate/sdp-api-client-go v1.0.5/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=


### PR DESCRIPTION
Updated to proper git tag 1.0.5, previously used development branch of same code during development of v16