### PR TITLE
Provider configuration updates

### DIFF
--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -150,6 +150,14 @@ var (
 	"messageOfTheDay": "Welcome to Appgate SDP."
 }
 `
+	loginResponse406 = `
+{
+	"id": "string",
+	"message": "string",
+	"minSupportedVersion": 7,
+	"maxSupportedVersion": 15
+}
+  `
 )
 
 func TestConfigGetToken(t *testing.T) {
@@ -224,6 +232,16 @@ func TestConfigGetToken(t *testing.T) {
 			expectedVersion: computed54TestVersion,
 			clientVersion:   15,
 			statusCode:      http.StatusServiceUnavailable,
+		},
+		{
+			name: "406 login response",
+			fields: fields{
+				ResponseBody: loginResponse406,
+			},
+			wantErr:         true,
+			expectedVersion: computed54TestVersion,
+			clientVersion:   99,
+			statusCode:      http.StatusNotAcceptable,
 		},
 	}
 	for _, tt := range tests {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.5
+	github.com/appgate/sdp-api-client-go v1.0.6
 	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0
+	github.com/imdario/mergo v0.3.12
 )

--- a/go.sum
+++ b/go.sum
@@ -61,14 +61,6 @@ github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
-github.com/appgate/sdp-api-client-go v1.0.5 h1:SeOQmS31ygVtm0jv2EEvyP9kaCmsDbY/7rimA1ML72A=
-github.com/appgate/sdp-api-client-go v1.0.5/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102125328-52c1d12ffdb4 h1:I1m99/Vyi4GJd16sKE5Wcn1RCgVj/0qHGiiHalwJNxo=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102125328-52c1d12ffdb4/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102130358-a66398344298 h1:Q7qY4OyYzomldnMHN3ljmXrLgAH+EW88hd6GfHNcna0=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102130358-a66398344298/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102135721-9654567a433a h1:9SHsUwycLmToj7Cuv+0ZdXEfQlNrCOgngVZx2jm6tb4=
-github.com/appgate/sdp-api-client-go v1.0.6-0.20211102135721-9654567a433a/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/appgate/sdp-api-client-go v1.0.6 h1:rhOi6Ezo+BYVIvWM/hVbrtGsI9reY0DNgqa03mHj6Pw=
 github.com/appgate/sdp-api-client-go v1.0.6/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,14 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/appgate/sdp-api-client-go v1.0.5 h1:SeOQmS31ygVtm0jv2EEvyP9kaCmsDbY/7rimA1ML72A=
 github.com/appgate/sdp-api-client-go v1.0.5/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102125328-52c1d12ffdb4 h1:I1m99/Vyi4GJd16sKE5Wcn1RCgVj/0qHGiiHalwJNxo=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102125328-52c1d12ffdb4/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102130358-a66398344298 h1:Q7qY4OyYzomldnMHN3ljmXrLgAH+EW88hd6GfHNcna0=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102130358-a66398344298/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102135721-9654567a433a h1:9SHsUwycLmToj7Cuv+0ZdXEfQlNrCOgngVZx2jm6tb4=
+github.com/appgate/sdp-api-client-go v1.0.6-0.20211102135721-9654567a433a/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.6 h1:rhOi6Ezo+BYVIvWM/hVbrtGsI9reY0DNgqa03mHj6Pw=
+github.com/appgate/sdp-api-client-go v1.0.6/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -74,7 +74,7 @@ $ terraform plan
 
 ### Config file
 
-Configure appgatesdp with a config file, can be combined with environment variables, if an `APPGATE_` environment variable is set, they take precedence over the config file.
+Configure appgatesdp with a config file, can be combined with environment variables, if an `APPGATE_` environment variable is set, they will merge with the config file, and the config file values take precedence over any existing values.
 
 ```hcl
 provider "appgatesdp" {
@@ -82,15 +82,27 @@ provider "appgatesdp" {
 }
 ```
 
-example config file format
+the following keys are allowed within the config file, all keys are optional.
+```json
+{
+    "appgate_url": "string",
+    "appgate_username": "string",
+    "appgate_password": "string",
+    "appgate_provider": "string",
+    "appgate_bearer_token": "string",
+    "appgate_client_version": 16,
+}
+
+```
+
+example config file format,
 ```json
 {
     "appgate_url": "https://controller.appgate/admin",
     "appgate_username": "admin",
     "appgate_password": "admin",
     "appgate_provider": "local",
-    "appgate_client_version": 16,
-    "appgate_insecure": true
+    "appgate_client_version": 16
 }
 
 ```
@@ -132,6 +144,9 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `config_path` - (Optional) Configure appgatesdp with a config file, if any environment variables is set, they take precedence.
 
+* `url` - (Optional) This is the Appgate controller API URL. It must be provided, but
+  it can also be sourced from the `APPGATE_ADDRESS` environment variable.
+
 * `username` - (Optional) This is the Appgate username. It must be provided, but
   it can also be sourced from the `APPGATE_USERNAME` environment variable.
 
@@ -143,6 +158,6 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `client_version` - (Optional) This reference the appgate client SDK version, it can also be sourced from the `APPGATE_CLIENT_VERSION` environment variables. Defaults to `16`, Its not recommended to change this unless you know what you are doing.
 
-* `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. As the name suggests this is insecure and should not be used beyond experiments, accessing local (non-production) GHE instance etc. There is a number of ways to obtain trusted certificate for free, e.g. from Let's Encrypt. Such trusted certificate does not require this option to be enabled. Defaults to `true`.
+* `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. As the name suggests this is insecure and should not be used beyond experiments, accessing local (non-production) GHE instance etc. There is a number of ways to obtain trusted certificate for free, e.g. from Let's Encrypt. Such trusted certificate does not require this option to be enabled. Defaults to `false`, it can also be sourced from the `APPGATE_INSECURE` environment variables.
 
 * `debug` - (Optional) Whether HTTP request should be displayed in debug mode, combine with [TF_LOG](https://www.terraform.io/docs/internals/debugging.html) Defaults to `false`.


### PR DESCRIPTION
This PR include improvement for configuration of the provider.

- This PR resolves merge issues seen in #185 , where the config file values was not included if default values was used.
- Changed default value of `insecure` / `APPGATE_INSECURE`, before the default value was `true`, but has now been updated to `false` as default. Since we want to tls verification on by default, and if you want to disable tls verification, you need to explicit set it to `false`.
- Updated error messages
   - Updated error message when using invalid peer version for your appgate sdp collective
   - Updated error message if you are trying to access the API with un-trusted tls certificate.  
- All provider attributes are now Optional in the schema, however we validate the input and make sure we have minimum required attributes set, independent of the origin.