### PR TITLE
Controller resource, support Controller in HA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.8.0
+VERSION=0.8.1
 
 
 build:

--- a/appgate/appliance_schemas.go
+++ b/appgate/appliance_schemas.go
@@ -1,0 +1,73 @@
+package appgate
+
+import "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+func allowSourcesSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"address": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validateIPaddress,
+				},
+				"netmask": {
+					Type:     schema.TypeInt,
+					Optional: true,
+				},
+				"nic": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func controllerSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		MaxItems: 1,
+		Optional: true,
+		Computed: true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"enabled": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+			},
+		},
+	}
+}
+
+func adminInterfaceSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"hostname": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"https_port": {
+					Type:     schema.TypeInt,
+					Default:  443,
+					Optional: true,
+				},
+				"https_ciphers": {
+					Type:        schema.TypeList,
+					Description: "The type of TLS ciphers to allow. See: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html for all supported ciphers.",
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+				"allow_sources": allowSourcesSchema(),
+			},
+		},
+	}
+}

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -40,7 +40,12 @@ type Config struct {
 }
 
 // Validate makes sure we have minimum required configuration values to authenticate against the controller.
-func (c *Config) Validate() error {
+func (c *Config) Validate(usingFile bool) error {
+	// we wont validate the configuration if we are using the config_file
+	// this is because we want defer it until the file has been populated.
+	if usingFile {
+		return nil
+	}
 	if !isUrl(c.URL) {
 		return fmt.Errorf("Controller URL is mandatory, got %q", c.URL)
 	}

--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -388,7 +388,7 @@ func TestConfigValidate(t *testing.T) {
 				Version:      tt.fields.Version,
 				BearerToken:  tt.fields.BearerToken,
 			}
-			if err := c.Validate(); (err != nil) != tt.wantErr {
+			if err := c.Validate(false); (err != nil) != tt.wantErr {
 				t.Errorf("Config.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -117,6 +117,7 @@ func Provider() *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"appgatesdp_appliance":                          resourceAppgateAppliance(),
+			"appgatesdp_appliance_controller_activation":    resourceAppgateApplianceControllerActivation(),
 			"appgatesdp_entitlement":                        resourceAppgateEntitlement(),
 			"appgatesdp_site":                               resourceAppgateSite(),
 			"appgatesdp_ringfence_rule":                     resourceAppgateRingfenceRule(),

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -232,7 +232,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		}
 	}
 
-	if err := config.Validate(); err != nil {
+	if err := config.Validate(usingFile); err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary:  "Missing Appgate SDP credentials",

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -18,29 +18,6 @@ import (
 )
 
 func resourceAppgateAppliance() *schema.Resource {
-	reUsableSchemas := make(map[string]*schema.Schema)
-
-	reUsableSchemas["allow_sources"] = &schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"address": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					ValidateFunc: validateIPaddress,
-				},
-				"netmask": {
-					Type:     schema.TypeInt,
-					Optional: true,
-				},
-				"nic": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-			},
-		},
-	}
 	return &schema.Resource{
 		Create: resourceAppgateApplianceCreate,
 		Read:   resourceAppgateApplianceRead,
@@ -135,7 +112,7 @@ func resourceAppgateAppliance() *schema.Resource {
 							Optional: true,
 						},
 
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 
 						"override_spa_mode": {
 							Type:     schema.TypeString,
@@ -179,36 +156,12 @@ func resourceAppgateAppliance() *schema.Resource {
 							Optional: true,
 							Default:  444,
 						},
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 					},
 				},
 			},
 
-			"admin_interface": {
-				Type:     schema.TypeList,
-				Optional: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"hostname": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"https_port": {
-							Type:     schema.TypeInt,
-							Default:  443,
-							Optional: true,
-						},
-						"https_ciphers": {
-							Type:        schema.TypeList,
-							Description: "The type of TLS ciphers to allow. See: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html for all supported ciphers.",
-							Optional:    true,
-							Elem:        &schema.Schema{Type: schema.TypeString},
-						},
-						"allow_sources": reUsableSchemas["allow_sources"],
-					},
-				},
-			},
+			"admin_interface": adminInterfaceSchema(),
 
 			"networking": {
 				Type:     schema.TypeList,
@@ -494,7 +447,7 @@ func resourceAppgateAppliance() *schema.Resource {
 							Default:  22,
 						},
 
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 
 						"password_authentication": {
 							Type:     schema.TypeBool,
@@ -534,7 +487,7 @@ func resourceAppgateAppliance() *schema.Resource {
 							Optional: true,
 						},
 
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 					},
 				},
 			},
@@ -558,7 +511,7 @@ func resourceAppgateAppliance() *schema.Resource {
 							Optional: true,
 						},
 
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 					},
 				},
 			},
@@ -582,7 +535,7 @@ func resourceAppgateAppliance() *schema.Resource {
 							Optional: true,
 						},
 
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 					},
 				},
 			},
@@ -594,7 +547,7 @@ func resourceAppgateAppliance() *schema.Resource {
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"allow_sources": reUsableSchemas["allow_sources"],
+						"allow_sources": allowSourcesSchema(),
 					},
 				},
 			},
@@ -622,21 +575,7 @@ func resourceAppgateAppliance() *schema.Resource {
 				},
 			},
 
-			"controller": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enabled": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
-						},
-					},
-				},
-			},
+			"controller": controllerSchema(),
 
 			"gateway": {
 				Type:          schema.TypeList,
@@ -944,7 +883,7 @@ func resourceAppgateAppliance() *schema.Resource {
 										Optional: true,
 									},
 
-									"allow_resources": reUsableSchemas["allow_sources"],
+									"allow_resources": allowSourcesSchema(),
 
 									"snat_to_tunnel": {
 										Type:     schema.TypeBool,

--- a/appgate/resource_appgate_appliance_controller.go
+++ b/appgate/resource_appgate_appliance_controller.go
@@ -1,0 +1,253 @@
+package appgate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAppgateApplianceControllerActivation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAppgateApplianceControllerActivationCreate,
+		ReadContext:   resourceAppgateApplianceControllerActivationRead,
+		UpdateContext: resourceAppgateApplianceControllerActivationUpdate,
+		DeleteContext: resourceAppgateApplianceControllerActivationDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+		Schema: func() map[string]*schema.Schema {
+			s := map[string]*schema.Schema{
+				"appliance_id": {
+					Type:        schema.TypeString,
+					Description: "ID of the object.",
+					Required:    true,
+				},
+				"controller":      controllerSchema(),
+				"admin_interface": adminInterfaceSchema(),
+			}
+			// all these fields are mandatory within this resource
+			s["admin_interface"].Optional = false
+			s["admin_interface"].Required = true
+			s["controller"].Optional = false
+			s["controller"].Required = true
+			s["controller"].Computed = false
+			return s
+		}(),
+	}
+}
+
+func resourceAppgateApplianceControllerActivationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type  var diags diag.Diagnostics
+	var diags diag.Diagnostics
+	Appliance54Constraints, err := version.NewConstraint(">= 5.4.0")
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	currentVersion := meta.(*Client).ApplianceVersion
+	if !Appliance54Constraints.Check(currentVersion) {
+		return diag.FromErr(errors.New("This resource is only avaliable in 5.4 or higher."))
+	}
+
+	id := d.Get("appliance_id").(string)
+	log.Printf("[DEBUG] Creating Appliance Controller activation with name: %s", id)
+	api := meta.(*Client).API.AppliancesApi
+	request := api.AppliancesIdGet(ctx, id)
+	appliance, res, err := request.Authorization(token).Execute()
+	if err != nil {
+		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("Failed to read Appliance, %+v", err))
+	}
+
+	if v := appliance.GetActivated(); !v {
+		return diag.FromErr(fmt.Errorf("Can not activate controller functions on an inactive appliance. The appliance %q need to be seeded first.", appliance.GetName()))
+	}
+	if v, ok := d.GetOk("controller"); ok {
+		ctrl, err := readControllerFromConfig(v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		appliance.SetController(ctrl)
+	}
+	if a, ok := d.GetOk("admin_interface"); ok {
+		ainterface, err := readAdminInterfaceFromConfig(a.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		appliance.SetAdminInterface(ainterface)
+	}
+
+	retryErr := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(appliance).Authorization(token).Execute()
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		// wait a few seconds and make sure the controller react to the changes.
+		time.Sleep(time.Duration(10) * time.Second)
+		if err := waitForControllers(ctx, meta); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("1 or more controller never reached a healthy state after enabling controller on %s: %s", appliance.GetName(), err))
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
+	}
+	d.SetId(appliance.Id)
+	resourceAppgateApplianceControllerActivationRead(ctx, d, meta)
+	return diags
+}
+
+func resourceAppgateApplianceControllerActivationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type  var diags diag.Diagnostics
+	var diags diag.Diagnostics
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	api := meta.(*Client).API.AppliancesApi
+	request := api.AppliancesIdGet(ctx, d.Id())
+	appliance, res, err := request.Authorization(token).Execute()
+	if err != nil {
+		d.SetId("")
+		if res.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("Failed to read Appliance, %+v", err))
+	}
+	d.SetId(appliance.Id)
+	if v, ok := appliance.GetControllerOk(); ok {
+		ctrl := make(map[string]interface{})
+		ctrl["enabled"] = v.GetEnabled()
+
+		if err := d.Set("controller", []interface{}{ctrl}); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	if v, ok := appliance.GetAdminInterfaceOk(); ok {
+		adminInterface, err := flattenApplianceAdminInterface(*v)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if err := d.Set("admin_interface", adminInterface); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return diags
+}
+
+func resourceAppgateApplianceControllerActivationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id := d.Get("appliance_id").(string)
+	log.Printf("[DEBUG] Updating Appliance controller: %s", id)
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	api := meta.(*Client).API.AppliancesApi
+	request := api.AppliancesIdGet(ctx, id)
+	appliance, _, err := request.Authorization(token).Execute()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Failed to read Appliance, %+v", err))
+	}
+	if v := appliance.GetActivated(); !v {
+		return diag.FromErr(fmt.Errorf("Can not activate controller functions on an inactive appliance. The appliance %q need to be seeded first.", appliance.GetName()))
+	}
+	if d.HasChange("controller") {
+		_, v := d.GetChange("controller")
+		ctrl, err := readControllerFromConfig(v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		appliance.SetController(ctrl)
+	}
+	if d.HasChange("admin_interface") {
+		_, v := d.GetChange("admin_interface")
+		ainterface, err := readAdminInterfaceFromConfig(v.([]interface{}))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		// since admin_interface is Optional, but admin_interface.hostname is required
+		// if it set, we will make sure that hostname is not None before we send the request
+		// to avoid sending empty fields in the request body.
+		// otherwise, admin_interface has been removed, and we can set admin_interface to nil
+		// and it will be omitted from the PUT request.
+		if v, ok := ainterface.GetHostnameOk(); ok && v != nil && len(*v) > 0 {
+			appliance.SetAdminInterface(ainterface)
+		} else {
+			appliance.AdminInterface = nil
+		}
+	}
+
+	retryErr := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(appliance).Authorization(token).Execute()
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Could not update appliance %+v", prettyPrintAPIError(err)))
+		}
+		// wait a few seconds and make sure the controller react to the changes.
+		time.Sleep(time.Duration(10) * time.Second)
+		if err := waitForControllers(ctx, meta); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("1 or more controller never reached a healthy state after updating controller on %s: %s", appliance.GetName(), err))
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
+	}
+
+	return resourceAppgateApplianceControllerActivationRead(ctx, d, meta)
+}
+
+func resourceAppgateApplianceControllerActivationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// Warning or errors can be collected in a slice type  var diags diag.Diagnostics
+	var diags diag.Diagnostics
+	id := d.Get("appliance_id").(string)
+	log.Printf("[DEBUG] Updating Appliance controller: %s", id)
+	token, err := meta.(*Client).GetToken()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	api := meta.(*Client).API.AppliancesApi
+	request := api.AppliancesIdGet(ctx, id)
+	appliance, _, err := request.Authorization(token).Execute()
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("Failed to read Appliance, %+v", err))
+	}
+	c := openapi.ApplianceAllOfController{}
+	c.SetEnabled(false)
+	appliance.SetController(c)
+
+	retryErr := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(appliance).Authorization(token).Execute()
+		if err != nil {
+			return resource.NonRetryableError(fmt.Errorf("Could not update appliance when disable controlleron %s %+v", appliance.Name, prettyPrintAPIError(err)))
+		}
+		// wait a few seconds and make sure the controller react to the changes.
+		time.Sleep(time.Duration(10) * time.Second)
+		if err := waitForControllers(ctx, meta); err != nil {
+			return resource.NonRetryableError(fmt.Errorf("1 or more controller never reached a healthy state after updating controller on %s: %s", appliance.GetName(), err))
+		}
+		return nil
+	})
+	if retryErr != nil {
+		return diag.FromErr(retryErr)
+	}
+	return diags
+}

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -309,7 +309,7 @@ const (
 
 // waitForApplianceState is a blocking function that does exponential backOff on appliance stats
 // and make sure a certain appliance has reached state.
-func waitForApplianceState(ctx context.Context, meta interface{}, applianceID, state string) error {
+func waitForApplianceState(ctx context.Context, meta interface{}, applianceID, state string, b *backoff.ExponentialBackOff) error {
 	return backoff.Retry(func() error {
 		statsAPI := meta.(*Client).API.ApplianceStatsApi
 		token, err := meta.(*Client).GetToken()
@@ -334,12 +334,5 @@ func waitForApplianceState(ctx context.Context, meta interface{}, applianceID, s
 			return nil
 		}
 		return fmt.Errorf("appliance %q is in state %s expected %s", applianceID, appliance.GetState(), state)
-	}, &backoff.ExponentialBackOff{
-		InitialInterval:     2 * time.Second,
-		RandomizationFactor: 0.7,
-		Multiplier:          2,
-		MaxInterval:         8 * time.Minute,
-		Stop:                backoff.Stop,
-		Clock:               backoff.SystemClock,
-	})
+	}, b)
 }

--- a/website/docs/guides/ha_controllers.markdown
+++ b/website/docs/guides/ha_controllers.markdown
@@ -1,0 +1,126 @@
+---
+layout: "appgatesdp"
+page_title: "high availability controllers"
+sidebar_current: "docs-appgatesdp-guide-high_availability_controllers"
+description: |-
+  Provisioning high availability controllers
+---
+
+## Provisioning high availability controllers
+
+
+In appliance >= 5.4.0 we cant create more then 1 controller at the time,
+it means that we must first create an appliance, seed it, then activate the controller function.
+
+
+For a full example see:
+- https://github.com/appgate/sdp-tf-reference-architecture/tree/main/deployment/aws/high-availability-controllers
+
+
+#### Create an appliance resource
+
+```hcl
+resource "appgatesdp_appliance" "second_controller" {
+  // ...
+  // Configure a plain appliance that will become the second controller
+  // You can configure everything here as normal expect the controller {} block
+  lifecycle {
+    ignore_changes = [
+      # The following attributes will be defined and configured within
+      # appgatesdp_appliance_controller_activation.activate_second_controller
+      admin_interface,
+      controller,
+    ]
+  }
+
+}
+
+```
+
+#### Create an instance to become the second controller
+
+The second step is to provision an instance with the appliance seed, for example an aws ec2 instance.
+```hcl
+
+data "appgatesdp_appliance_seed" "second_controller_seed" {
+  depends_on = [
+    appgatesdp_appliance.second_controller,
+  ]
+  appliance_id   = appgatesdp_appliance.second_controller.id
+  password       = "cz"
+  latest_version = true
+}
+
+
+resource "aws_instance" "appgatesdp_second_controller_instance" {
+  // ...
+  depends_on = [
+    appgatesdp_appliance.second_controller,
+  ]
+}
+```
+
+
+#### Provision the instance with the appliance configuration.
+
+Third step is to seed the instance
+```hcl
+
+resource "null_resource" "seed_controller" {
+  depends_on = [
+    appgatesdp_appliance.second_controller,
+  ]
+
+
+  connection {
+    type        = "ssh"
+    user        = "cz"
+    timeout     = "25m"
+    private_key = file(var.private_key)
+    host        = aws_instance.second_controller.public_dns
+  }
+
+  provisioner "local-exec" {
+    command = "echo ${data.appgatesdp_appliance_seed.second_controller_seed.seed_file} > seed.b64"
+  }
+  provisioner "file" {
+    source      = "seed.b64"
+    destination = "/home/cz/seed.b64"
+  }
+  provisioner "remote-exec" {
+    inline = [
+      "cat seed.b64 | base64 -d  | jq .  >> seed.json",
+      // wait for the seed to get picked up and initialized
+      "sleep 20",
+      "echo OK",
+    ]
+  }
+}
+```
+
+#### Enable controller function
+
+Once the second controller is seeded with the default appliance configuration, we can enable the controller functionallity.
+
+```hcl
+resource "appgatesdp_appliance_controller_activation" "activate_second_controller" {
+  depends_on = [
+    aws_instance.appgatesdp_second_controller_instance,
+    null_resource.seed_controller,
+  ]
+  appliance_id = appgatesdp_appliance.second_controller.id
+  controller {
+    enabled = true
+  }
+  admin_interface {
+    hostname   = aws_instance.appgatesdp_second_controller_instance.public_dns
+    https_port = 8443
+    https_ciphers = [
+      "ECDHE-RSA-AES256-GCM-SHA384",
+      "ECDHE-RSA-AES128-GCM-SHA256"
+    ]
+  }
+}
+```
+
+

--- a/website/docs/r/appgatesdp_appliance_controller_activation.markdown
+++ b/website/docs/r/appgatesdp_appliance_controller_activation.markdown
@@ -10,6 +10,10 @@ description: |-
 # appgatesdp_appliance_controller_activation
 
 Activate controller functionallity on a appliance.
+
+
+~> **NOTE:**  The resource is only available in >= 5.4 appliances. When destroying this resource, it will disable the controller function on the appliance, and the appliance will remain.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/appgatesdp_appliance_controller_activation.markdown
+++ b/website/docs/r/appgatesdp_appliance_controller_activation.markdown
@@ -1,0 +1,56 @@
+---
+layout: "appgatesdp"
+page_title: "APPGATE: appgatesdp_appliance"
+sidebar_current: "docs-appgate-resource-appliance_controller_activation"
+description: |-
+   Activate an controller
+---
+
+
+# appgatesdp_appliance_controller_activation
+
+Activate controller functionallity on a appliance.
+## Example Usage
+
+```hcl
+resource "appgatesdp_appliance_controller_activation" "activate_second_controller" {
+  appliance_id = appgatesdp_appliance.second_controller.id
+  controller {
+    enabled = true
+  }
+  admin_interface {
+    hostname   = "second_controller.com"
+    https_port = 8443
+    https_ciphers = [
+      "ECDHE-RSA-AES256-GCM-SHA384",
+      "ECDHE-RSA-AES128-GCM-SHA256"
+    ]
+  }
+}
+
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `controller`: (Required) Controller settings.
+* `admin_interface`: (Required) The details of the admin connection interface.
+
+
+### controller
+Controller settings.
+
+* `enabled`:  (Optional)  default value `false` Whether the Controller is enabled on this appliance or not. Cannot be enabled on an inactive Appliance since some checks need to be done first.
+
+
+### admin_interface
+The details of the admin connection interface. Required on Controllers and LogServers.
+
+* `hostname`: (Required) Hostname to connect to the admin interface. This hostname will be used to validate the appliance certificate. Example: appgate.company.com.
+* `https_port`:  (Optional)  default value `8443` Port to connect for admin services.
+* `https_ciphers`: (Required)  default value `ECDHE-RSA-AES256-GCM-SHA384,ECDHE-RSA-AES128-GCM-SHA256` The type of TLS ciphers to allow. See: https://www.openssl.org/docs/man1.0.2/apps/ciphers.html for all supported ciphers.
+* `allow_sources`:  (Optional) Source configuration to allow via iptables.
+
+

--- a/website/docs/r/appgatesdp_appliance_controller_activation.markdown
+++ b/website/docs/r/appgatesdp_appliance_controller_activation.markdown
@@ -14,6 +14,10 @@ Activate controller functionallity on a appliance.
 
 ~> **NOTE:**  The resource is only available in >= 5.4 appliances. When destroying this resource, it will disable the controller function on the appliance, and the appliance will remain.
 
+
+!> **Warning:** You wont be able to use this in a safe way on more then 1 appliance at the time.
+
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
New resource,  `appgatesdp_appliance_controller_activation`. This will allow us to enable controller functionallity on a pre-existing, seeded appliance instance.

While reviewing, start with reading the `*.markdown` files before the code for extra context.


Acceptance tests has been omitted since we have not yet created the required testing infrastructure for this, however I've thoroughly tested this manually, and created an example usage here: 

- https://github.com/appgate/sdp-tf-reference-architecture/tree/high-availability-controllers/deployment/aws/high-availability-controllers

This PR will solve the problems explained in https://github.com/appgate/terraform-provider-appgatesdp/issues/188


acceptance test on 5.4.2-25749-release

<details>

```bash
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestConfigGetToken
=== RUN   TestConfigGetToken/test_before_5.4
2021/11/12 17:01:29 [DEBUG] Login OK
=== RUN   TestConfigGetToken/test_5.4_login
2021/11/12 17:01:29 [DEBUG] Login OK
=== RUN   TestConfigGetToken/invalid_client_version
=== RUN   TestConfigGetToken/500_login_response
2021/11/12 17:01:29 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/11/12 17:01:30 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestConfigGetToken/502_login_response
2021/11/12 17:01:30 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/11/12 17:01:31 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestConfigGetToken/503_login_response
2021/11/12 17:01:31 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/11/12 17:01:31 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestConfigGetToken/406_login_response
--- PASS: TestConfigGetToken (1.61s)
    --- PASS: TestConfigGetToken/test_before_5.4 (0.00s)
    --- PASS: TestConfigGetToken/test_5.4_login (0.00s)
    --- PASS: TestConfigGetToken/invalid_client_version (0.00s)
    --- PASS: TestConfigGetToken/500_login_response (0.55s)
    --- PASS: TestConfigGetToken/502_login_response (0.59s)
    --- PASS: TestConfigGetToken/503_login_response (0.46s)
    --- PASS: TestConfigGetToken/406_login_response (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (8.47s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.93s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.67s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.90s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.57s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.52s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.57s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.70s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.01s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.27s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.58s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (13.18s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.72s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.91s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.95s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccApplianceLogForwarderElastic55
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccApplianceConnector
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3010: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.15s)
=== CONT  TestAccDeviceScriptBasic
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.29s)
=== CONT  TestAccCriteriaScriptBasic
--- SKIP: TestAccAppliancePortalSetup (1.50s)
=== CONT  TestAccConditionBasic
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.62s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.58s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccGlobalSettings54ProfileHostname (8.29s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccBlacklistUserBasic (6.67s)
=== CONT  TestAccSite55Attributes
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.35s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccTrustedCertificateBasic (8.58s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccDeviceScriptBasic (7.51s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccEntitlementScriptBasic (8.81s)
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccSite55Attributes
    resource_appgate_site_test.go:717: Test only for 5.5 and above, dns_forwarding only supported in > 5.5
--- PASS: TestAccCriteriaScriptBasic (7.94s)
=== CONT  TestAccPolicyDnsSettings55
--- SKIP: TestAccSite55Attributes (1.09s)
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccConditionBasic (8.05s)
=== CONT  TestAccPolicyBasic
=== CONT  TestAccPolicyDnsSettings55
    resource_appgate_policy_test.go:320: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccEntitlementBasicPing (10.19s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccApplianceConnector (10.28s)
=== CONT  TestAccadministrativeRoleWithScope
--- SKIP: TestAccPolicyDnsSettings55 (1.21s)
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccPolicyClientSettings55
    resource_appgate_policy_test.go:146: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccPolicyClientSettings55 (1.37s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (11.23s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (11.25s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (11.33s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccLdapIdentityProviderBasic (11.64s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccApplianceBasicGateway (11.65s)
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.05s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceCustomizationBasic (13.31s)
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.32s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccAdminMfaSettingsBasic (7.66s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccApplianceAdminInterfaceAddRemove (16.25s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
--- PASS: TestAccRingfenceRuleBasicICMP (7.80s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccAppgateMfaProviderDataSource (6.59s)
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.52s)
--- PASS: TestAccRingfenceRuleBasicTCP (8.30s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.16s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.74s)
--- PASS: TestAccPolicyBasic (8.01s)
--- PASS: TestAccadministrativeRoleBasic (8.08s)
--- PASS: TestAccLocalUserBasic (7.23s)
--- PASS: TestAccMfaProviderBasic (7.31s)
--- PASS: TestAccEntitlementBasicWithMonitor (18.58s)
--- PASS: TestAccadministrativeRoleWithScope (8.33s)
--- PASS: TestAccIPPoolV6 (6.97s)
--- PASS: TestAccIPPoolBasic (6.97s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (18.63s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (4.85s)
--- PASS: TestAccRadiusIdentityProviderBasic (8.00s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (14.89s)
--- PASS: TestAccEntitlementUpdateActionOrder (10.36s)
--- PASS: TestAccSamlIdentityProviderBasic (18.78s)
--- PASS: TestAccSiteBasic (23.56s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	116.742s
```
</details>