### PR TITLE
Improved error message ctrl activate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.8.2
+VERSION=0.8.3
 
 
 build:

--- a/appgate/resource_appgate_appliance_controller.go
+++ b/appgate/resource_appgate_appliance_controller.go
@@ -99,7 +99,7 @@ func resourceAppgateApplianceControllerActivationCreate(ctx context.Context, d *
 	retryErr := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(appliance).Authorization(token).Execute()
 		if err != nil {
-			return resource.NonRetryableError(err)
+			return resource.NonRetryableError(prettyPrintAPIError(err))
 		}
 		b := &backoff.ExponentialBackOff{
 			InitialInterval:     10 * time.Second,


### PR DESCRIPTION
Include full error message body to user, in the example below, an validation error occurred during create and prompted error message `Error: 422 `, now it includes the full error message.

Before:
```

appgatesdp_appliance_controller_activation.activate_second_controller: Creating...
╷
│ Error: 422 
│ 
│   with appgatesdp_appliance_controller_activation.activate_second_controller,
│   on main.tf line 13, in resource "appgatesdp_appliance_controller_activation" "activate_second_controller":
│   13: resource "appgatesdp_appliance_controller_activation" "activate_second_controller" {
│ 
╵

```



After:
```
appgatesdp_appliance_controller_activation.activate_second_controller: Creating...
╷
│ Error: Validation error Validation failed. 
│  adminInterface.hostname is not a valid FQDN or IP address.
│ 
│ 
│   with appgatesdp_appliance_controller_activation.activate_second_controller,
│   on main.tf line 13, in resource "appgatesdp_appliance_controller_activation" "activate_second_controller":
│   13: resource "appgatesdp_appliance_controller_activation" "activate_second_controller" {
│ 
╵
```