### PR TITLE
fixed device_id instead of random each time

### DIFF
--- a/appgate/config.go
+++ b/appgate/config.go
@@ -17,8 +17,6 @@ import (
 	"github.com/appgate/sdp-api-client-go/api/v16/openapi"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-version"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -39,6 +37,7 @@ type Config struct {
 	Version      int    `json:"appgate_client_version,omitempty"`
 	BearerToken  string `json:"appgate_bearer_token,omitempty"`
 	PemFilePath  string `json:"appgate_pem_filepath,omitempty"`
+	DeviceID     string `json:"appgate_device_id,omitempty"`
 }
 
 // Validate makes sure we have minimum required configuration values to authenticate against the controller.
@@ -216,7 +215,7 @@ func (c *Client) login() (*openapi.LoginResponse, error) {
 		ProviderName: c.Config.Provider,
 		Username:     openapi.PtrString(c.Config.Username),
 		Password:     openapi.PtrString(c.Config.Password),
-		DeviceId:     uuid.New().String(),
+		DeviceId:     c.Config.DeviceID,
 	}
 
 	// Since /login is the first request we do, it provide us the earliest check if a controller is up and running

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/appgate/sdp-api-client-go v1.0.6
 	github.com/cenkalti/backoff/v4 v4.1.2
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -163,3 +163,6 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `insecure` - (Optional) Whether server should be accessed without verifying the TLS certificate. As the name suggests this is insecure and should not be used beyond experiments, accessing local (non-production) GHE instance etc. There is a number of ways to obtain trusted certificate for free, e.g. from Let's Encrypt. Such trusted certificate does not require this option to be enabled. Defaults to `false`, it can also be sourced from the `APPGATE_INSECURE` environment variables.
 
 * `debug` - (Optional) Whether HTTP request should be displayed in debug mode, combine with [TF_LOG](https://www.terraform.io/docs/internals/debugging.html) Defaults to `false`.
+
+* `device_id` - (Optional) UUID to distinguish the Client device making the request. It is supposed to be same for every login request from the same server. Defaults to `/etc/machine-id` if omitted.
+


### PR DESCRIPTION
new optional provider attribute, `device_id`

Usage:

```hcl
provider "appgatesdp" {
  device_id = "ba20c1a2-b903-4b84-b6f1-2962c1460672" 
}
```

if `device_id` is not set, fallback to /etc/machine-id in a UUID format