### PR TITLE
Http proxy for the client

### DIFF
--- a/appgate/config.go
+++ b/appgate/config.go
@@ -107,7 +107,13 @@ func (c *Config) Client() (*Client, error) {
 		}).Dial,
 		TLSHandshakeTimeout: timeoutDuration * time.Second,
 	}
-
+	if key, ok := os.LookupEnv("HTTP_PROXY"); ok {
+		proxyURL, err := url.Parse(key)
+		if err != nil {
+			return nil, err
+		}
+		tr.Proxy = http.ProxyURL(proxyURL)
+	}
 	httpclient := &http.Client{
 		Transport: tr,
 		Timeout:   ((timeoutDuration * 2) * time.Second),


### PR DESCRIPTION
Tested with [mitmproxy](https://mitmproxy.org/) on localhost, works fine. Configurable only with environment variable `HTTP_PROXY` since I dont think this should be include in the default provider configuration, but I am open for suggestions.

Example Usage:

`HTTP_PROXY="http://proxyIp:proxyPort"`

![](https://user-images.githubusercontent.com/1218385/145580075-3854b0fd-f1a9-404f-9a88-b7549c4a76d2.png)
