### PR TITLE
Issue 204 - CRUD fix for site.vpn.RouteVia

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=0.8.4
+VERSION=0.8.5
 
 
 build:

--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -665,14 +665,13 @@ func flattenSiteVPN(currentVersion *version.Version, in openapi.SiteAllOfVpn) []
 		}
 		m["tls"] = []interface{}{tls}
 	}
-
-	if in.HasRouteVia() && in.RouteVia.Ipv4 != nil {
+	if in.HasRouteVia() && (in.RouteVia.Ipv4 != nil || in.RouteVia.Ipv6 != nil) {
 		routeVia := make(map[string]interface{})
-		if _, o := in.RouteVia.GetIpv4Ok(); o {
-			routeVia["ipv4"] = in.RouteVia.GetIpv4()
+		if v, o := in.RouteVia.GetIpv4Ok(); o && len(*v) > 0 {
+			routeVia["ipv4"] = v
 		}
-		if _, o := in.RouteVia.GetIpv6Ok(); o {
-			routeVia["ipv6"] = in.RouteVia.GetIpv6()
+		if v, o := in.RouteVia.GetIpv6Ok(); o && len(*v) > 0 {
+			routeVia["ipv6"] = v
 		}
 		m["route_via"] = []interface{}{routeVia}
 	}
@@ -1086,11 +1085,11 @@ func readSiteVPNRouteViaFromConfig(routeViaConf []interface{}) (openapi.SiteAllO
 		}
 
 		raw := r.(map[string]interface{})
-		if r, ok := raw["ipv4"]; ok {
-			result.SetIpv4(r.(string))
+		if v, ok := raw["ipv4"].(string); ok && len(v) > 0 {
+			result.SetIpv4(v)
 		}
-		if r, ok := raw["ipv6"]; ok {
-			result.SetIpv6(r.(string))
+		if v, ok := raw["ipv6"].(string); ok && len(v) > 0 {
+			result.SetIpv6(v)
 		}
 	}
 	return result, nil

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -1111,3 +1111,277 @@ func testAccSiteVPNRouteViaDeleted(context map[string]interface{}) string {
       }
 `, context)
 }
+
+// Test for
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/204
+func TestAccSiteVPNRouteViaIpv4Only(t *testing.T) {
+	resourceName := "appgatesdp_site.d_test_site"
+	rName := RandStringFromCharSet(11, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name": rName,
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSiteDestroy,
+		Steps: []resource.TestStep{
+			{
+
+				Config: testAccSiteVPNRouteViaIpv4Only(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v4", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v6", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.excluded_subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_based_routing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_mappings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.esx_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.gcp_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.use_hosts_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", "DT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "default_test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.ip_access_log_interval_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.ipv4", "10.10.10.10"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.ipv6", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.snat", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.state_sharing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_key_store", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_verify_upstream_certificate", "false"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+			{
+
+				Config: testAccSiteVPNRouteViaIpv4OnlyUpdated(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v4", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v6", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.excluded_subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_based_routing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_mappings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.esx_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.gcp_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.use_hosts_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", "DT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "default_test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.ip_access_log_interval_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.ipv4", "10.20.10.20"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.ipv6", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.snat", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.state_sharing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_key_store", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_verify_upstream_certificate", "false"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+			{
+
+				Config: testAccSiteVPNRouteViaIpv4OnlyUpdatedWithIpv6(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v4", "true"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.enabled_v6", "false"),
+					resource.TestCheckResourceAttr(resourceName, "default_gateway.0.excluded_subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_based_routing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_mappings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.esx_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.gcp_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.use_hosts_file", "false"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "short_name", "DT"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "default_test"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.%", "9"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.dtls.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.ip_access_log_interval_seconds", "120"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.route_via.0.ipv6", "fdf8:f53b:82e4::53"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.snat", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.state_sharing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.tls.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_key_store", ""),
+					resource.TestCheckResourceAttr(resourceName, "vpn.0.web_proxy_verify_upstream_certificate", "false"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/204
+func testAccSiteVPNRouteViaIpv4Only(context map[string]interface{}) string {
+	return Nprintf(`
+resource "appgatesdp_site" "d_test_site" {
+	name                      = "%{name}"
+	short_name                = "DT"
+	entitlement_based_routing = false
+	notes                     = "Managed by terraform"
+
+	default_gateway {
+	  enabled_v4 = true
+	  enabled_v6 = false
+	}
+	vpn {
+	  state_sharing                  = false
+	  ip_access_log_interval_seconds = 120
+	  snat                           = false
+	  tls {
+		enabled = true
+	  }
+	  dtls {
+		enabled = false
+	  }
+	  route_via {
+		ipv4 = "10.10.10.10"
+	  }
+	}
+	tags = ["terraform", "api-created", "default_test"]
+}
+`, context)
+}
+
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/204
+func testAccSiteVPNRouteViaIpv4OnlyUpdated(context map[string]interface{}) string {
+	return Nprintf(`
+resource "appgatesdp_site" "d_test_site" {
+	name                      = "%{name}"
+	short_name                = "DT"
+	entitlement_based_routing = false
+	notes                     = "Managed by terraform"
+
+	default_gateway {
+	  enabled_v4 = true
+	  enabled_v6 = false
+	}
+	vpn {
+	  state_sharing                  = false
+	  ip_access_log_interval_seconds = 120
+	  snat                           = false
+	  tls {
+		enabled = true
+	  }
+	  dtls {
+		enabled = false
+	  }
+	  route_via {
+		ipv4 = "10.20.10.20"
+	  }
+	}
+	tags = ["terraform", "api-created", "default_test"]
+}
+`, context)
+}
+
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/204
+func testAccSiteVPNRouteViaIpv4OnlyUpdatedWithIpv6(context map[string]interface{}) string {
+	return Nprintf(`
+resource "appgatesdp_site" "d_test_site" {
+	name                      = "%{name}"
+	short_name                = "DT"
+	entitlement_based_routing = false
+	notes                     = "Managed by terraform"
+
+	default_gateway {
+	  enabled_v4 = true
+	  enabled_v6 = false
+	}
+	vpn {
+	  state_sharing                  = false
+	  ip_access_log_interval_seconds = 120
+	  snat                           = false
+	  tls {
+		enabled = true
+	  }
+	  dtls {
+		enabled = false
+	  }
+	  route_via {
+		ipv6 = "fdf8:f53b:82e4::53"
+	  }
+	}
+	tags = ["terraform", "api-created", "default_test"]
+}
+`, context)
+}


### PR DESCRIPTION
This PR resolves the issue reported in #204 

Before it sent empty string ` "ipv6": ""` , this has now been resolved

Example payload of the request body before this PR based on the HCL config in #204 
```json
{
    "defaultGateway": {
        "enabledV4": true,
        "enabledV6": false
    },
    "description": "",
    "entitlementBasedRouting": false,
    "id": "0a11985c-a81a-4585-abc0-b8aefdea5e08",
    "name": "default test",
    "notes": "Managed by terraform",
    "shortName": "DT",
    "tags": [
        "api-created",
        "default_test",
        "terraform"
    ],
    "vpn": {
        "dtls": {
            "enabled": false
        },
        "ipAccessLogIntervalSeconds": 120,
        "routeVia": {
            "ipv4": "10.10.10.10",
            "ipv6": ""
        },
        "snat": false,
        "stateSharing": false,
        "tls": {
            "enabled": true
        }
    }
}
```



Acceptance test for 5.3.4-24950


<details>


```bash
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2021/12/29 10:46:01 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2021/12/29 10:46:01 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2021/12/29 10:46:01 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/12/29 10:46:02 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2021/12/29 10:46:02 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/12/29 10:46:02 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2021/12/29 10:46:02 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/12/29 10:46:03 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2021/12/29 10:46:03 [DEBUG] Login OK
--- PASS: TestClient (1.63s)
    --- PASS: TestClient/test_before_5.4 (0.02s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.55s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.63s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.88s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.39s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.66s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.38s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.54s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.76s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.83s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (11.36s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.56s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.53s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (38.29s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.40s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.82s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.19s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (8.59s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (7.57s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSite55Attributes
=== CONT  TestAccIPPoolV6
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccSite55Attributes
    resource_appgate_site_test.go:717: Test only for 5.5 and above, dns_forwarding only supported in > 5.5
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccGlobalSettings54ProfileHostname
    resource_appgate_global_settings_test.go:102: Test only for 5.4 and above, client_connections profile_hostname is not supported prior to 5.4, you are using 5.3.0+estimated
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.03s)
=== CONT  TestAccDeviceScriptBasic
--- SKIP: TestAccSite55Attributes (1.05s)
=== CONT  TestAccCriteriaScriptBasic
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.13s)
=== CONT  TestAccConditionBasic
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.15s)
=== CONT  TestAccBlacklistUserBasic
--- SKIP: TestAccGlobalSettings54ProfileHostname (1.16s)
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3010: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.21s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.29s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccIPPoolV6 (7.74s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2170: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccIPPoolBasic (7.93s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- SKIP: TestAccAppliancePortalSetup (0.91s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccLocalUserBasic (8.52s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (8.66s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccBlacklistUserBasic (7.67s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccTrustedCertificateBasic (8.97s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccCriteriaScriptBasic (8.20s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccEntitlementScriptBasic (9.31s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccConditionBasic (8.36s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.88s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccDeviceScriptBasic (8.97s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicPing (10.21s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccLdapIdentityProviderBasic (10.88s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccRadiusIdentityProviderBasic (11.63s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (11.71s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.13s)
=== CONT  TestAccPolicyDnsSettings55
--- PASS: TestAccAppgateApplianceCustomizationDataSource (7.04s)
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.83s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccAppgateMfaProviderDataSource (7.25s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccPolicyDnsSettings55
    resource_appgate_policy_test.go:320: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccadministrativeRoleBasic (8.83s)
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccPolicyClientSettings55
    resource_appgate_policy_test.go:146: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccPolicyDnsSettings55 (1.16s)
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccPolicyClientSettings55 (0.84s)
--- PASS: TestAccPolicyBasic (7.74s)
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.04s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (10.74s)
--- PASS: TestAccApplianceBasicGateway (10.55s)
--- PASS: TestAccEntitlementUpdateActionOrder (18.77s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (16.45s)
--- PASS: TestAccEntitlementBasicWithMonitor (18.85s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (11.11s)
--- PASS: TestAccApplianceConnector (10.76s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (19.31s)
--- PASS: TestAccadministrativeRoleWithScope (10.01s)
--- PASS: TestAccRingfenceRuleBasicICMP (7.69s)
--- PASS: TestAccRingfenceRuleBasicTCP (7.77s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (19.40s)
--- PASS: TestAccApplianceCustomizationBasic (11.30s)
--- PASS: TestAccAdminMfaSettingsBasic (3.90s)
--- PASS: TestAccMfaProviderBasic (4.30s)
--- PASS: TestAccSamlIdentityProviderBasic (16.00s)
--- PASS: TestAccSiteBasic (22.28s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	158.182s

```


</details>




Acceptance tests for 5.5.0-26293-release
<details>


```bash
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2021/12/29 10:50:00 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2021/12/29 10:50:00 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2021/12/29 10:50:00 [DEBUG] Login failed, controller not responding, got HTTP 500
2021/12/29 10:50:00 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2021/12/29 10:50:00 [DEBUG] Login failed, controller not responding, got HTTP 502
2021/12/29 10:50:01 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2021/12/29 10:50:01 [DEBUG] Login failed, controller not responding, got HTTP 503
2021/12/29 10:50:02 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2021/12/29 10:50:02 [DEBUG] Login OK
--- PASS: TestClient (1.62s)
    --- PASS: TestClient/test_before_5.4 (0.02s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.55s)
    --- PASS: TestClient/502_login_response (0.59s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (7.81s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.28s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.91s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.66s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.50s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.96s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.94s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.87s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.09s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.59s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.61s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (48.69s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.75s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.19s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.10s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (7.84s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (8.48s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSite55Attributes
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccSiteBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccApplianceConnector
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.24s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (7.76s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccTrustedCertificateBasic (8.68s)
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccRingfenceRuleBasicTCP (8.74s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccRingfenceRuleBasicICMP (8.93s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccEntitlementScriptBasic (9.32s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.57s)
=== CONT  TestAccLocalUserBasic
--- PASS: TestAccSite55Attributes (9.79s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (11.22s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccApplianceConnector (11.37s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccEntitlementBasicPing (11.53s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccApplianceBasicGateway (11.73s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (11.80s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceCustomizationBasic (13.57s)
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic (1.03s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
--- PASS: TestAccPolicyDnsSettings55 (16.58s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccAdminMfaSettingsBasic (7.85s)
=== CONT  TestAccConditionBasic
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic (0.99s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccMfaProviderBasic (8.45s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccLocalUserBasic (8.35s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccPolicyBasic (9.51s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccIPPoolV6 (8.75s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (11.04s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccEntitlementUpdateActionHostOrder (18.97s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccEntitlementUpdateActionOrder (19.66s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (19.81s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccIPPoolBasic (8.79s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccadministrativeRoleBasic (8.64s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (8.52s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccEntitlementBasicWithMonitor (20.26s)
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic (0.98s)
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (0.88s)
--- PASS: TestAccadministrativeRoleWithScope (9.33s)
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (10.97s)
--- PASS: TestAccPolicyClientSettings55 (14.89s)
--- PASS: TestAccAppgateMfaProviderDataSource (6.12s)
--- PASS: TestAccBlacklistUserBasic (5.24s)
--- PASS: TestAccConditionBasic (7.50s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.09s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.87s)
--- PASS: TestAccDeviceScriptBasic (7.04s)
--- PASS: TestAccCriteriaScriptBasic (6.84s)
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (9.21s)
--- PASS: TestAccGlobalSettings54ProfileHostname (5.61s)
--- PASS: TestAccApplianceLogForwarderElastic55 (8.10s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (7.39s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (10.76s)
--- PASS: TestAccSiteBasic (32.16s)


--- PASS: TestAccAppliancePortalSetup (45.94s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	184.871s

```


</details>