### PR TITLE
Resolve issue in appliance network configuration

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -2742,8 +2742,8 @@ func readGatewayFromConfig(gateways []interface{}) (openapi.ApplianceAllOfGatewa
 						if v := raw["address"].(string); v != "" {
 							ad.SetAddress(v)
 						}
-						if v, ok := raw["netmask"]; ok {
-							ad.SetNetmask(int32(v.(int)))
+						if v, ok := raw["netmask"].(int); ok && v > 0 {
+							ad.SetNetmask(int32(v))
 						}
 						if v := raw["nic"].(string); v != "" {
 							ad.SetNic(v)

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -1287,7 +1287,7 @@ func readNetworkNicsFromConfig(hosts []interface{}) ([]openapi.ApplianceAllOfNet
 			ipv4networking := openapi.ApplianceAllOfNetworkingIpv4{}
 			for _, item := range v {
 				ipv4Data := item.(map[string]interface{})
-				if item, ok := ipv4Data["dhcp"].([]interface{}); ok && len(v) > 0 && item[0] != nil {
+				if item, ok := ipv4Data["dhcp"].([]interface{}); ok && len(item) > 0 && item[0] != nil {
 					ipv4networking.SetDhcp(readNetworkIpv4DhcpFromConfig(item[0].(map[string]interface{})))
 				}
 				if item := ipv4Data["static"]; len(item.([]interface{})) > 0 {

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -1285,7 +1285,6 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 				Config: testAccCheckApplianceBasicGateway(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplianceExists(resourceName),
-
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
 					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
@@ -1296,8 +1295,8 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", "127.0.0.1"),
-					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
 
@@ -1320,6 +1319,13 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
 					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.address", "10.10.10.1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.hostname", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.0.snat", "true"),
 				),
 			},
 			{
@@ -1381,6 +1387,11 @@ resource "appgatesdp_appliance" "test_gateway" {
           routers = true
           ntp     = true
         }
+		static {
+			address = "10.10.10.1"
+			netmask = 24
+			snat    = true
+		}
       }
       ipv6 {
         dhcp {
@@ -1396,8 +1407,6 @@ resource "appgatesdp_appliance" "test_gateway" {
     vpn {
       weight = 100
       allow_destinations {
-        address = "127.0.0.1"
-        netmask = 32
         nic     = "eth0"
       }
     }


### PR DESCRIPTION
This PR addresses issues reported in #207  and #208 

Acceptance tests for 5.4.2-25749-release
<details>



```sh

make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/02/07 10:24:48 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/02/07 10:24:48 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/02/07 10:24:48 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/02/07 10:24:49 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/02/07 10:24:49 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/02/07 10:24:49 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/02/07 10:24:49 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/02/07 10:24:50 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/02/07 10:24:50 [DEBUG] Login OK
--- PASS: TestClient (1.63s)
    --- PASS: TestClient/test_before_5.4 (0.03s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.56s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.46s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (8.30s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.10s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.76s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (13.23s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.76s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.64s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.93s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.08s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.16s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.75s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.67s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (41.73s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.86s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.66s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.70s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (7.87s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (7.63s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccSiteBasic
=== CONT  TestAccIPPoolV6
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccSite55Attributes
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccPolicyClientSettings55
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccPolicyClientSettings55
    resource_appgate_policy_test.go:146: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
=== CONT  TestAccPolicyDnsSettings55
    resource_appgate_policy_test.go:320: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2179: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
=== CONT  TestAccSite55Attributes
    resource_appgate_site_test.go:717: Test only for 5.5 and above, dns_forwarding only supported in > 5.5
--- SKIP: TestAccPolicyDnsSettings55 (1.13s)
=== CONT  TestAccConditionBasic
--- SKIP: TestAccPolicyClientSettings55 (1.13s)
=== CONT  TestAccBlacklistUserBasic
--- SKIP: TestAccAppliancePortalSetup (1.24s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- SKIP: TestAccSite55Attributes (1.38s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3019: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.49s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (9.10s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.93s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccCriteriaScriptBasic (10.43s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccTrustedCertificateBasic (10.64s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccIPPoolV6 (10.92s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccEntitlementScriptBasic (10.91s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccBlacklistUserBasic (9.89s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccRingfenceRuleBasicICMP (11.14s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccRingfenceRuleBasicTCP (11.37s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccDeviceScriptBasic (11.40s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccLocalUserBasic (11.66s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccConditionBasic (10.55s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.31s)
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccEntitlementBasicPing (13.10s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.54s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccPolicyBasic (10.81s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.28s)
=== CONT  TestAccLdapIdentityProviderBasic
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.52s)
=== CONT  TestAccAppgateMfaProviderDataSource
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.71s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccAdminMfaSettingsBasic (11.03s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccMfaProviderBasic (10.91s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (10.87s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccIPPoolBasic (10.30s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccApplianceAdminInterfaceAddRemove (21.90s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicWithMonitor (23.53s)
--- PASS: TestAccEntitlementUpdateActionOrder (23.53s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (23.54s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (23.76s)
--- PASS: TestAccAppgateMfaProviderDataSource (9.11s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (13.54s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (13.28s)
--- PASS: TestAccApplianceConnector (13.32s)
--- PASS: TestAccApplianceBasicGateway (13.55s)
--- PASS: TestAccRadiusIdentityProviderBasic (13.52s)
--- PASS: TestAccadministrativeRoleWithScope (10.55s)
--- PASS: TestAccLdapIdentityProviderBasic (11.91s)
--- PASS: TestAccApplianceCustomizationBasic (15.41s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (6.42s)
--- PASS: TestAccadministrativeRoleBasic (7.83s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.03s)
--- PASS: TestAccGlobalSettings54ProfileHostname (7.14s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (8.10s)
--- PASS: TestAccSiteBasic (36.19s)
--- PASS: TestAccSamlIdentityProviderBasic (23.52s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	165.674s
```

</details>


Acceptance tests for 5.5.4-27454-release

<details>



```sh
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/02/07 10:25:33 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/02/07 10:25:33 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/02/07 10:25:33 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/02/07 10:25:33 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/02/07 10:25:33 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/02/07 10:25:34 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/02/07 10:25:34 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/02/07 10:25:34 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/02/07 10:25:34 [DEBUG] Login OK
--- PASS: TestClient (1.62s)
    --- PASS: TestClient/test_before_5.4 (0.02s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.56s)
    --- PASS: TestClient/502_login_response (0.59s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (12.65s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.74s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (3.51s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (18.90s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.71s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.60s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.95s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.81s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (17.39s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (11.83s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.81s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (27.94s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (3.93s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.52s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.49s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (10.73s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (10.61s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccSite55Attributes
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccSiteBasic
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccConditionBasic
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccBlacklistUserBasic (8.32s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccAppgateAdministrativeRoleDataSource (8.41s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccConditionBasic (9.78s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccRingfenceRuleBasicICMP (9.80s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccTrustedCertificateBasic (9.84s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (9.92s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccLocalUserBasic (9.93s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccCriteriaScriptBasic (10.28s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccRingfenceRuleBasicTCP (10.61s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccDeviceScriptBasic (10.64s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccSite55Attributes (10.88s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccEntitlementScriptBasic (11.02s)
=== CONT  TestAccadministrativeRoleBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.96s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccEntitlementBasicPing (11.83s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccAppgateMfaProviderDataSource (6.40s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccPolicyDnsSettings55 (18.25s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccPolicyClientSettings55 (18.28s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (7.96s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.36s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccadministrativeRoleBasic (8.00s)
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic (1.26s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceLogForwarderElastic55 (13.07s)
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic (0.90s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceConnector (12.64s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccApplianceBasicGateway (12.86s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
--- PASS: TestAccadministrativeRoleWithScope (12.14s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (13.25s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (13.30s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccEntitlementUpdateActionOrder (23.30s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccEntitlementUpdateActionHostOrder (23.42s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (23.42s)
--- PASS: TestAccApplianceCustomizationBasic (13.15s)
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccEntitlementBasicWithMonitor (23.70s)
--- SKIP: TestAccLdapIdentityProviderBasic (0.74s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (0.87s)
--- PASS: TestAccAdminMfaSettingsBasic (6.93s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (7.02s)
--- PASS: TestAccPolicyBasic (8.05s)
--- PASS: TestAccIPPoolBasic (7.54s)
--- PASS: TestAccIPPoolV6 (7.64s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (19.90s)
--- PASS: TestAccMfaProviderBasic (5.99s)
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (9.73s)
--- PASS: TestAccGlobalSettings54ProfileHostname (6.79s)
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (8.97s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (8.88s)
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (9.06s)
--- PASS: TestAccSiteBasic (36.46s)
--- PASS: TestAccAppliancePortalSetup (42.45s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	204.047s

```



</details>