### PR TITLE
Appgatesdp policy/dns settings

### DIFF
--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -331,6 +331,9 @@ func resourceAppgatePolicyCreate(d *schema.ResourceData, meta interface{}) error
 			args.SetOverrideSiteClaim(v.(string))
 		}
 		if v, ok := d.GetOk("dns_settings"); ok {
+			if args.GetType() != "Dns" {
+				return fmt.Errorf("appgatesdp_policy.dns_settings is only allowed on policy Type 'Dns', got %q", args.GetType())
+			}
 			servers, err := readPolicyDnsSettingsFromConfig(v.(*schema.Set).List())
 			if err != nil {
 				return err
@@ -640,7 +643,7 @@ func flattenPolicyClientSettings(clientSettings openapi.PolicyAllOfClientSetting
 }
 
 func flattenPolicyDnsSettings(dnsSettings []openapi.PolicyAllOfDnsSettings) (*schema.Set, error) {
-	out := make([]interface{}, 0, 0)
+	out := make([]interface{}, 0)
 	for _, dnsSetting := range dnsSettings {
 		m := make(map[string]interface{})
 		if v, ok := dnsSetting.GetDomainOk(); ok {
@@ -769,6 +772,9 @@ func resourceAppgatePolicyUpdate(d *schema.ResourceData, meta interface{}) error
 			orginalPolicy.SetOverrideSiteClaim(d.Get("override_site_claim").(string))
 		}
 		if d.HasChange("dns_settings") {
+			if orginalPolicy.GetType() != "Dns" {
+				return fmt.Errorf("appgatesdp_policy.dns_settings is only allowed on policy Type 'Dns', got %q", orginalPolicy.GetType())
+			}
 			_, v := d.GetChange("dns_settings")
 			dnsSettings, err := readPolicyDnsSettingsFromConfig(v.(*schema.Set).List())
 			if err != nil {

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -165,11 +165,10 @@ func resourceAppgatePolicy() *schema.Resource {
 			},
 
 			"dns_settings": {
-				Type:             schema.TypeSet,
-				Optional:         true,
-				Description:      "List of domain names with DNS server IPs that the Client should be using.",
-				DiffSuppressFunc: suppressMissingOptionalConfigurationBlock,
-				Set:              resourcePolicyDnsSettingsHash,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of domain names with DNS server IPs that the Client should be using.",
+				Set:         resourcePolicyDnsSettingsHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"domain": {

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -261,6 +261,10 @@ func resourceAppgatePolicy() *schema.Resource {
 }
 
 func resourcePolicyDnsSettingsHash(v interface{}) int {
+	var buf bytes.Buffer
+	if v == nil {
+		return hashcode.String(buf.String())
+	}
 	raw := v.(map[string]interface{})
 	// modifying raw actually modifies the values passed to the provider.
 	// Use a copy to avoid that.
@@ -268,7 +272,7 @@ func resourcePolicyDnsSettingsHash(v interface{}) int {
 	for key, value := range raw {
 		copy[key] = value
 	}
-	var buf bytes.Buffer
+
 	buf.WriteString(fmt.Sprintf("%s-", copy["domain"].(string)))
 	if v, ok := copy["servers"]; ok {
 		buf.WriteString(fmt.Sprintf("%v-", v.(*schema.Set).List()))

--- a/appgate/resource_appgate_policy_test.go
+++ b/appgate/resource_appgate_policy_test.go
@@ -428,6 +428,54 @@ func TestAccPolicyDnsSettings55(t *testing.T) {
 				ImportState:      true,
 				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
 			},
+			{
+				Config: testAccCheckPolicyDnsSettingsDeleted(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "administrative_roles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.%", "10"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.add_remove_profiles", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.attention_level", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.auto_start", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.entitlements_list", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.keep_me_signed_in", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.quit", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.saml_auto_sign_in", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.sign_out", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "client_settings.0.suspend", "Show"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "dns_settings.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "entitlement_links.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "entitlements.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", context["updated_name"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "override_site_claim", ""),
+					resource.TestCheckResourceAttr(resourceName, "proxy_auto_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "proxy_auto_config.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "proxy_auto_config.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "proxy_auto_config.0.persist", "false"),
+					resource.TestCheckResourceAttr(resourceName, "proxy_auto_config.0.url", ""),
+					resource.TestCheckResourceAttr(resourceName, "ringfence_rule_links.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ringfence_rules.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "api-created"),
+					resource.TestCheckResourceAttr(resourceName, "tags.1", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "tags.2", "updated"),
+					resource.TestCheckResourceAttr(resourceName, "tamper_proofing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_network_check.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_network_check.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "trusted_network_check.0.dns_suffix", ""),
+					resource.TestCheckResourceAttr(resourceName, "trusted_network_check.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Dns"),
+				),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccCriteriaScripImportStateCheckFunc(1),
+			},
 		},
 	})
 }
@@ -473,6 +521,25 @@ resource "appgatesdp_policy" "dns_policy_with_dns_settings" {
 		domain  = "google.com"
 		servers = ["2.2.2.2", "3.3.3.3"]
 	}
+	expression = <<-EOF
+	var result = false;
+	return result;
+	EOF
+}
+`, context)
+}
+
+func testAccCheckPolicyDnsSettingsDeleted(context map[string]interface{}) string {
+	return Nprintf(`
+resource "appgatesdp_policy" "dns_policy_with_dns_settings" {
+	name = "%{updated_name}"
+	type = "Dns"
+	tags = [
+		"terraform",
+		"api-created",
+		"updated",
+	]
+	disabled = false
 	expression = <<-EOF
 	var result = false;
 	return result;


### PR DESCRIPTION
This PR resolves issue #211

suppressMissingOptionalConfigurationBlock conflicts with custom Set hash value. 

Acceptance test for 5.5.4-27454-release

<details>


```sh
 make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/02/21 09:31:57 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/02/21 09:31:57 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/02/21 09:31:57 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/02/21 09:31:58 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/02/21 09:31:58 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/02/21 09:31:58 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/02/21 09:31:58 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/02/21 09:31:59 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/02/21 09:31:59 [DEBUG] Login OK
--- PASS: TestClient (1.65s)
    --- PASS: TestClient/test_before_5.4 (0.03s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.56s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.46s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (7.58s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.23s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (3.13s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (14.76s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.62s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.60s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.66s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.73s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.27s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.95s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.94s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (50.63s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.97s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.98s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.54s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (9.34s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (7.88s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccSite55Attributes
=== CONT  TestAccPolicyClientSettings55
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccPolicyBasic
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccSiteBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccIPPoolV6
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccRingfenceRuleBasicTCP (10.43s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccAppgateAdministrativeRoleDataSource (10.93s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (11.04s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccLocalUserBasic (11.14s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccAdminMfaSettingsBasic (11.82s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccTrustedCertificateBasic (12.27s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccMfaProviderBasic (12.35s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccPolicyBasic (12.42s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccIPPoolV6 (12.68s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccIPPoolBasic (12.72s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccRingfenceRuleBasicICMP (12.84s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccSite55Attributes (13.01s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (14.77s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccPolicyClientSettings55 (21.22s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccBlacklistUserBasic (10.12s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccCriteriaScriptBasic (11.29s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccDeviceScriptBasic (11.52s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccEntitlementScriptBasic (11.71s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccConditionBasic (11.26s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.33s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementBasicPing (13.65s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (24.14s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccEntitlementBasicWithMonitor (24.71s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccEntitlementUpdateActionHostOrder (24.80s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccApplianceLogForwarderElastic55 (13.52s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccEntitlementUpdateActionOrder (25.88s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- SKIP: TestAccSamlIdentityProviderBasic (1.22s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccApplianceBasicGateway (13.50s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (14.08s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccadministrativeRoleWithScope (13.97s)
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic (1.03s)
--- SKIP: TestAccRadiusIdentityProviderBasic (1.29s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (0.99s)
--- PASS: TestAccApplianceConnector (12.86s)
--- PASS: TestAccPolicyDnsSettings55 (29.08s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (7.27s)
--- PASS: TestAccAppgateMfaProviderDataSource (8.31s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (7.55s)
--- PASS: TestAccadministrativeRoleBasic (8.75s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (9.31s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (19.86s)
--- PASS: TestAccGlobalSettings54ProfileHostname (6.84s)
--- PASS: TestAccApplianceCustomizationBasic (13.02s)
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (10.36s)
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (10.42s)
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (9.73s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (8.71s)
--- PASS: TestAccSiteBasic (40.26s)
--- PASS: TestAccAppliancePortalSetup (34.93s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	190.098s


```

</details>


Acceptance test for 5.4.2-25749-release

<details>


```sh

> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/02/21 09:38:19 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/02/21 09:38:19 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/02/21 09:38:19 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/02/21 09:38:20 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/02/21 09:38:20 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/02/21 09:38:20 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/02/21 09:38:20 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/02/21 09:38:21 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/02/21 09:38:21 [DEBUG] Login OK
--- PASS: TestClient (1.65s)
    --- PASS: TestClient/test_before_5.4 (0.03s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.56s)
    --- PASS: TestClient/502_login_response (0.59s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.84s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.02s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.66s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.97s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.61s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.64s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.07s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.92s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (12.85s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (8.63s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.02s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (13.26s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (3.14s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (4.05s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (4.00s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (8.42s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (8.25s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccApplianceConnector
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccConditionBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccBlacklistUserBasic
=== CONT  TestAccSite55Attributes
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
=== CONT  TestAccApplianceLogForwarderElastic55
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccEntitlementScriptBasic
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccSite55Attributes
    resource_appgate_site_test.go:717: Test only for 5.5 and above, dns_forwarding only supported in > 5.5
=== CONT  TestAccApplianceLogForwarderElastic55
    resource_appgate_appliance_test.go:3019: Test only for 5.5 and above, appliance.log_forwarder_elasticseach specific testcase
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccSite55Attributes (1.61s)
=== CONT  TestAccadministrativeRoleWithScope
--- SKIP: TestAccApplianceLogForwarderElastic55 (1.67s)
=== CONT  TestAccadministrativeRoleBasic
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (2.03s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccBlacklistUserBasic (11.71s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccCriteriaScriptBasic (11.75s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccTrustedCertificateBasic (12.17s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccAppgateTrustedCertificateDataSource (10.14s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccAppgateAdministrativeRoleDataSource (12.18s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccEntitlementScriptBasic (12.42s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccDeviceScriptBasic (13.11s)
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccAppliancePortalSetup
    resource_appgate_appliance_test.go:2179: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (13.75s)
=== CONT  TestAccPolicyDnsSettings55
--- SKIP: TestAccAppliancePortalSetup (1.64s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (14.25s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccLocalUserBasic (14.26s)
=== CONT  TestAccRingfenceRuleBasicICMP
--- PASS: TestAccEntitlementBasicPing (14.38s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccConditionBasic (14.44s)
=== CONT  TestAccPolicyClientSettings55
=== CONT  TestAccPolicyDnsSettings55
    resource_appgate_policy_test.go:320: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- PASS: TestAccadministrativeRoleBasic (13.34s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- SKIP: TestAccPolicyDnsSettings55 (1.67s)
=== CONT  TestAccIPPoolV6
=== CONT  TestAccPolicyClientSettings55
    resource_appgate_policy_test.go:146: Test only for 5.5 and above, appliance.portal is only supported in 5.4 and above.
--- SKIP: TestAccPolicyClientSettings55 (1.66s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccApplianceConnector (16.13s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccadministrativeRoleWithScope (14.99s)
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_saml_test.go:857: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic55OrGreater (1.81s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_radius_test.go:265: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic55OrGreater (1.76s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccApplianceCustomizationBasic (21.64s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccAppgateMfaProviderDataSource (11.10s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccAppgateApplianceCustomizationDataSource (11.78s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
    resource_appgate_identity_provider_ldap_certificate_test.go:293: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (1.85s)
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
    resource_appgate_identity_provider_ldap_test.go:257: Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic55OrGreater (1.78s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccRingfenceRuleBasicTCP (12.28s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccPolicyBasic (12.16s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (26.80s)
--- PASS: TestAccEntitlementUpdateActionOrder (27.43s)
--- PASS: TestAccRingfenceRuleBasicICMP (13.44s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (27.80s)
--- PASS: TestAccApplianceBasicGateway (15.08s)
--- PASS: TestAccIPPoolV6 (12.86s)
--- PASS: TestAccIPPoolBasic (12.41s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (16.34s)
--- PASS: TestAccEntitlementBasicWithMonitor (28.64s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (16.55s)
--- PASS: TestAccRadiusIdentityProviderBasic (15.03s)
--- PASS: TestAccAdminMfaSettingsBasic (10.47s)
--- PASS: TestAccMfaProviderBasic (9.59s)
--- PASS: TestAccGlobalSettings54ProfileHostname (7.43s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (21.62s)
--- PASS: TestAccLdapIdentityProviderBasic (10.00s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic (8.73s)
--- PASS: TestAccSamlIdentityProviderBasic (25.92s)
--- PASS: TestAccSiteBasic (31.53s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	152.397s


```

</details>