### PR TITLE
Dns forwarding allow destinations no limit

### DIFF
--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -462,7 +462,6 @@ func resourceAppgateSite() *schema.Resource {
 									"allow_destinations": {
 										Type:     schema.TypeSet,
 										Required: true,
-										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"address": {

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -749,6 +749,96 @@ func TestAccSite55Attributes(t *testing.T) {
                             dns_servers         = [
                                 "1.1.1.1"
                             ]
+							allow_destinations {
+								address = "1.1.1.1"
+								netmask = 32
+							}
+							allow_destinations {
+								address = "0.0.0.0"
+								netmask = 0
+							}
+							allow_destinations {
+								address = "::"
+								netmask = 0
+							}
+                        }
+                    }
+                }
+                `, map[string]interface{}{
+					"name": rName,
+				}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSiteExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.aws_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.client_id", "test_client"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.name", "AZ resolver 99"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.secret", "test_secret"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.subscription_id", "AZ_test_subscription"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.tenant_id", "AZ_test_tentant"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.update_interval", "60"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.azure_resolvers.0.use_managed_identities", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.1.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.1.address", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.1.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.2.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.2.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.allow_destinations.2.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.dns_servers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.dns_servers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.site_ipv4", "1.2.3.4"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_forwarding.0.site_ipv6", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.dns_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.esx_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.gcp_resolvers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name_resolution.0.use_hosts_file", "false")),
+			},
+			{
+				ResourceName:     resourceName,
+				ImportState:      true,
+				ImportStateCheck: testAccSiteImportStateCheckFunc(1),
+			},
+			{
+				// Delete 2 dns_forwarding.allow_destinations
+				Config: Nprintf(`
+                resource "appgatesdp_site" "test_site" {
+                    name       = "%{name}"
+                    tags = [
+                        "developer",
+                        "api-created"
+                    ]
+                    entitlement_based_routing = false
+                    network_subnets = [
+                        "10.0.0.0/16"
+                    ]
+                    default_gateway {
+                        enabled_v4       = false
+                        enabled_v6       = false
+                        excluded_subnets = []
+                    }
+                    name_resolution {
+                        azure_resolvers {
+                            name                    = "AZ resolver 99"
+                            client_id               = "test_client"
+                            secret                  = "test_secret"
+                            update_interval         = 60
+                            use_managed_identities  = true
+                            subscription_id         = "AZ_test_subscription"
+                            tenant_id               = "AZ_test_tentant"
+                        }
+                        dns_forwarding {
+                            site_ipv4           = "1.2.3.4"
+                            site_ipv6           = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+                            dns_servers         = [
+                                "1.1.1.1"
+                            ]
                             allow_destinations {
                                 address = "1.1.1.1"
                                 netmask = 32


### PR DESCRIPTION
This PR fixes #214 

Acceptance test for 5.5.4-27454-release

<details>


```sh
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/02/21 14:31:12 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/02/21 14:31:12 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/02/21 14:31:12 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/02/21 14:31:13 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/02/21 14:31:13 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/02/21 14:31:13 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/02/21 14:31:13 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/02/21 14:31:14 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/02/21 14:31:14 [DEBUG] Login OK
--- PASS: TestClient (1.65s)
    --- PASS: TestClient/test_before_5.4 (0.03s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.55s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (7.63s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.00s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (2.57s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (12.32s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (2.59s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (2.48s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.79s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.76s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (11.68s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (7.77s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (2.91s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (48.46s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (3.38s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (3.90s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.85s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (8.15s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (8.10s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
=== CONT  TestAccSite55Attributes
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccApplianceBasicGateway
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccApplianceConnector
=== CONT  TestAccSiteBasic
=== CONT  TestAccApplianceCustomizationBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccIPPoolV6
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.76s)
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccAppgateAdministrativeRoleDataSource (11.17s)
=== CONT  TestAccPolicyBasic
--- PASS: TestAccLocalUserBasic (12.50s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccIPPoolBasic (12.54s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccTrustedCertificateBasic (12.90s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccIPPoolV6 (13.45s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (13.50s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccRingfenceRuleBasicICMP (13.74s)
=== CONT  TestAccLdapIdentityProviderBasic
--- PASS: TestAccRingfenceRuleBasicTCP (13.99s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccApplianceConnector (15.12s)
=== CONT  TestAccSamlIdentityProviderBasic
--- SKIP: TestAccLdapIdentityProviderBasic (1.80s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
--- PASS: TestAccApplianceBasicGateway (15.72s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (15.88s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (17.07s)
=== CONT  TestAccCriteriaScriptBasic
--- SKIP: TestAccSamlIdentityProviderBasic (2.06s)
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic (2.27s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccApplianceCustomizationBasic (22.66s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccPolicyDnsSettings55 (24.96s)
=== CONT  TestAccDeviceScriptBasic
--- PASS: TestAccAdminMfaSettingsBasic (12.56s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccPolicyBasic (14.26s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccPolicyClientSettings55 (23.95s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccMfaProviderBasic (13.58s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- PASS: TestAccadministrativeRoleBasic (13.55s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccSite55Attributes (26.46s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
--- PASS: TestAccEntitlementUpdateActionOrder (27.13s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (13.79s)
=== CONT  TestAccAppliancePortalSetup
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccEntitlementUpdateActionHostOrder (28.00s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccadministrativeRoleWithScope (14.69s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (2.02s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (28.83s)
--- PASS: TestAccCriteriaScriptBasic (12.80s)
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (17.63s)
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (17.46s)
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (17.52s)
--- PASS: TestAccEntitlementBasicPing (15.57s)
--- PASS: TestAccEntitlementScriptBasic (12.76s)
--- PASS: TestAccBlacklistUserBasic (10.50s)
--- PASS: TestAccConditionBasic (11.17s)
--- PASS: TestAccGlobalSettings54ProfileHostname (10.76s)
--- PASS: TestAccDeviceScriptBasic (12.06s)
--- PASS: TestAccAppgateTrustedCertificateDataSource (9.40s)
--- PASS: TestAccAppgateMfaProviderDataSource (9.73s)
--- PASS: TestAccAppgateApplianceCustomizationDataSource (9.34s)
--- PASS: TestAccApplianceLogForwarderElastic55 (13.12s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (12.40s)
--- PASS: TestAccEntitlementBasicWithMonitor (22.69s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (15.72s)
--- PASS: TestAccSiteBasic (45.48s)
--- PASS: TestAccAppliancePortalSetup (51.91s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	214.179s

```

</details>