### PR TITLE
Issue 212 netmask

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -2742,7 +2742,7 @@ func readGatewayFromConfig(gateways []interface{}) (openapi.ApplianceAllOfGatewa
 						if v := raw["address"].(string); v != "" {
 							ad.SetAddress(v)
 						}
-						if v, ok := raw["netmask"].(int); ok && v > 0 {
+						if v, ok := raw["netmask"].(int); ok && v >= 0 {
 							ad.SetNetmask(int32(v))
 						}
 						if v := raw["nic"].(string); v != "" {

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -1295,7 +1295,7 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", "0.0.0.0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
 					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
@@ -1408,6 +1408,8 @@ resource "appgatesdp_appliance" "test_gateway" {
       weight = 100
       allow_destinations {
         nic     = "eth0"
+        address = "0.0.0.0"
+        netmask = 0
       }
     }
   }


### PR DESCRIPTION
This PR resolve issue reported in #212 
allow `0` as netmask


Acceptance test for 5.5.4-27454-release

<details>


```sh
> make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/03/02 14:31:43 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/03/02 14:31:43 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/03/02 14:31:43 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/03/02 14:31:44 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/03/02 14:31:44 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/03/02 14:31:44 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/03/02 14:31:44 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/03/02 14:31:45 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/03/02 14:31:45 [DEBUG] Login OK
--- PASS: TestClient (1.65s)
    --- PASS: TestClient/test_before_5.4 (0.05s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.55s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.46s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (10.42s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (2.95s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (3.71s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (19.34s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (3.30s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (3.41s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (3.95s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (3.78s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (15.60s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (10.90s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (3.38s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (18.71s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (3.60s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (5.13s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (5.63s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (10.42s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (10.20s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccRadiusIdentityProviderBasic
=== CONT  TestAccIPPoolV6
=== CONT  TestAccIPPoolBasic
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
=== CONT  TestAccEntitlementUpdateActionHostOrder
=== CONT  TestAccLdapIdentityProviderBasic
=== CONT  TestAccSamlIdentityProviderBasic
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== CONT  TestAccEntitlementUpdateActionOrder
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccEntitlementBasicWithMonitor
=== CONT  TestAccGlobalSettings54ProfileHostname
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccPolicyBasic
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccRadiusIdentityProviderBasic (1.13s)
=== CONT  TestAccEntitlementBasicPing
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic (1.50s)
=== CONT  TestAccEntitlementScriptBasic
--- SKIP: TestAccLdapIdentityProviderBasic (1.64s)
=== CONT  TestAccDeviceScriptBasic
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (1.69s)
=== CONT  TestAccCriteriaScriptBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (9.12s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccIPPoolV6 (10.90s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccTrustedCertificateBasic (11.07s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccIPPoolBasic (11.21s)
=== CONT  TestAccApplianceAdminInterfaceAddRemove
--- PASS: TestAccLocalUserBasic (11.21s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccGlobalSettings54ProfileHostname (11.34s)
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccPolicyBasic (11.50s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccRingfenceRuleBasicICMP (11.60s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccEntitlementScriptBasic (10.30s)
=== CONT  TestAccApplianceConnector
--- PASS: TestAccCriteriaScriptBasic (10.12s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccDeviceScriptBasic (10.37s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (1.65s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (14.30s)
=== CONT  TestAccadministrativeRoleWithScope
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (14.41s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccEntitlementBasicPing (13.48s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (14.70s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (14.80s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccBlacklistUserBasic (8.21s)
=== CONT  TestAccPolicyDnsSettings55
--- PASS: TestAccConditionBasic (10.39s)
=== CONT  TestAccPolicyClientSettings55
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (22.70s)
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
--- PASS: TestAccAppgateApplianceCustomizationDataSource (8.43s)
=== CONT  TestAccSite55Attributes
--- PASS: TestAccAppgateMfaProviderDataSource (8.63s)
=== CONT  TestAccAdminMfaSettingsBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (8.81s)
=== CONT  TestAccMfaProviderBasic
--- PASS: TestAccEntitlementUpdateActionHostOrder (23.52s)
=== CONT  TestAccSiteBasic
--- PASS: TestAccadministrativeRoleBasic (9.67s)
=== CONT  TestAccRingfenceRuleBasicTCP
--- PASS: TestAccApplianceConnector (12.60s)
--- PASS: TestAccEntitlementUpdateActionOrder (24.63s)
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (13.47s)
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (11.15s)
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (13.50s)
--- PASS: TestAccApplianceBasicGateway (13.54s)
--- PASS: TestAccEntitlementBasicWithMonitor (25.54s)
--- PASS: TestAccApplianceLogForwarderElastic55 (14.53s)
--- PASS: TestAccApplianceCustomizationBasic (14.39s)
--- PASS: TestAccadministrativeRoleWithScope (12.15s)
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (7.26s)
--- PASS: TestAccAdminMfaSettingsBasic (6.98s)
--- PASS: TestAccMfaProviderBasic (7.05s)
--- PASS: TestAccRingfenceRuleBasicTCP (6.93s)
--- PASS: TestAccApplianceAdminInterfaceAddRemove (20.18s)
--- PASS: TestAccPolicyClientSettings55 (12.94s)
--- PASS: TestAccSite55Attributes (12.10s)
--- PASS: TestAccPolicyDnsSettings55 (16.37s)
--- PASS: TestAccSiteBasic (23.79s)
--- PASS: TestAccAppliancePortalSetup (38.55s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	185.882s

```

</details>