### PR TITLE
add missing attribute, user_scripts to identity_providers

### DIFF
--- a/appgate/identity_provider.go
+++ b/appgate/identity_provider.go
@@ -97,6 +97,11 @@ func identityProviderSchema() map[string]*schema.Schema {
 				Computed: true,
 				Optional: true,
 			},
+			"user_scripts": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"dns_servers": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -378,6 +383,13 @@ func readProviderFromConfig(d *schema.ResourceData, provider openapi.IdentityPro
 	}
 	if v, ok := d.GetOk("ip_pool_v6"); ok {
 		provider.SetIpPoolV6(v.(string))
+	}
+	if v, ok := d.GetOk("user_scripts"); ok {
+		us, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if err != nil {
+			return &provider, err
+		}
+		provider.SetUserScripts(us)
 	}
 	if v, ok := d.GetOk("dns_servers"); ok {
 		servers, err := readArrayOfStringsFromConfig(v.([]interface{}))

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -99,6 +99,9 @@ func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, me
 	if provider.IpPoolV6 != nil {
 		args.SetIpPoolV6(*provider.IpPoolV6)
 	}
+	if provider.UserScripts != nil {
+		args.SetUserScripts(provider.GetUserScripts())
+	}
 	if provider.DnsServers != nil {
 		args.SetDnsServers(*provider.DnsServers)
 	}
@@ -223,6 +226,7 @@ func resourceAppgateLdapCertificateProviderRuleRead(d *schema.ResourceData, meta
 		d.Set("ip_pool_v6", *v)
 	}
 
+	d.Set("user_scripts", ldap.GetUserScripts())
 	d.Set("dns_servers", ldap.GetDnsServers())
 	d.Set("dns_search_domains", ldap.GetDnsSearchDomains())
 	d.Set("block_local_dns_requests", ldap.GetBlockLocalDnsRequests())
@@ -321,6 +325,14 @@ func resourceAppgateLdapCertificateProviderRuleUpdate(d *schema.ResourceData, me
 	}
 	if d.HasChange("ip_pool_v6") {
 		originalLdapCertificateProvider.SetIpPoolV6(d.Get("ip_pool_v6").(string))
+	}
+	if d.HasChange("user_scripts") {
+		_, v := d.GetChange("user_scripts")
+		us, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("Failed to read user_scripts %w", err)
+		}
+		originalLdapCertificateProvider.SetUserScripts(us)
 	}
 	if d.HasChange("dns_servers") {
 		_, v := d.GetChange("dns_servers")

--- a/appgate/resource_appgate_identity_provider_local_database.go
+++ b/appgate/resource_appgate_identity_provider_local_database.go
@@ -123,6 +123,7 @@ func resourceAppgateLocalDatabaseProviderRuleRead(d *schema.ResourceData, meta i
 		d.Set("ip_pool_v6", v)
 	}
 
+	d.Set("user_scripts", localDatabase.GetUserScripts())
 	d.Set("dns_servers", localDatabase.GetDnsServers())
 	d.Set("dns_search_domains", localDatabase.GetDnsSearchDomains())
 	d.Set("block_local_dns_requests", localDatabase.GetBlockLocalDnsRequests())
@@ -190,6 +191,14 @@ func resourceAppgateLocalDatabaseProviderRuleUpdate(d *schema.ResourceData, meta
 	}
 	if d.HasChange("ip_pool_v6") {
 		originalLocalDatabaseProvider.SetIpPoolV6(d.Get("ip_pool_v6").(string))
+	}
+	if d.HasChange("user_scripts") {
+		_, v := d.GetChange("user_scripts")
+		us, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("Failed to read user_scripts %w", err)
+		}
+		originalLocalDatabaseProvider.SetUserScripts(us)
 	}
 	if d.HasChange("dns_servers") {
 		_, v := d.GetChange("dns_servers")

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -109,6 +109,9 @@ func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interf
 	if provider.IpPoolV6 != nil {
 		args.SetIpPoolV6(*provider.IpPoolV6)
 	}
+	if provider.UserScripts != nil {
+		args.SetUserScripts(provider.GetUserScripts())
+	}
 	if provider.DnsServers != nil {
 		args.SetDnsServers(*provider.DnsServers)
 	}
@@ -193,6 +196,7 @@ func resourceAppgateRadiusProviderRuleRead(d *schema.ResourceData, meta interfac
 		d.Set("ip_pool_v6", *v)
 	}
 
+	d.Set("user_scripts", radius.GetUserScripts())
 	d.Set("dns_servers", radius.GetDnsServers())
 	d.Set("dns_search_domains", radius.GetDnsSearchDomains())
 	d.Set("block_local_dns_requests", radius.GetBlockLocalDnsRequests())
@@ -275,6 +279,14 @@ func resourceAppgateRadiusProviderRuleUpdate(d *schema.ResourceData, meta interf
 	}
 	if d.HasChange("ip_pool_v6") {
 		originalRadiusProvider.SetIpPoolV6(d.Get("ip_pool_v6").(string))
+	}
+	if d.HasChange("user_scripts") {
+		_, v := d.GetChange("user_scripts")
+		us, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("Failed to read user_scripts %w", err)
+		}
+		originalRadiusProvider.SetUserScripts(us)
 	}
 	if d.HasChange("dns_servers") {
 		_, v := d.GetChange("dns_servers")

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -101,6 +101,9 @@ func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interfac
 	if provider.IpPoolV6 != nil {
 		args.SetIpPoolV6(*provider.IpPoolV6)
 	}
+	if provider.UserScripts != nil {
+		args.SetUserScripts(provider.GetUserScripts())
+	}
 	if provider.DnsServers != nil {
 		args.SetDnsServers(*provider.DnsServers)
 	}
@@ -185,6 +188,7 @@ func resourceAppgateSamlProviderRuleRead(d *schema.ResourceData, meta interface{
 		d.Set("ip_pool_v6", v)
 	}
 
+	d.Set("user_scripts", saml.GetUserScripts())
 	d.Set("dns_servers", saml.GetDnsServers())
 	d.Set("dns_search_domains", saml.GetDnsSearchDomains())
 	d.Set("block_local_dns_requests", saml.GetBlockLocalDnsRequests())
@@ -258,6 +262,14 @@ func resourceAppgateSamlProviderRuleUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("ip_pool_v6") {
 		originalSamlProvider.SetIpPoolV6(d.Get("ip_pool_v6").(string))
+	}
+	if d.HasChange("user_scripts") {
+		_, v := d.GetChange("user_scripts")
+		scripts, err := readArrayOfStringsFromConfig(v.([]interface{}))
+		if err != nil {
+			return fmt.Errorf("Failed to read user_scripts %w", err)
+		}
+		originalSamlProvider.SetUserScripts(scripts)
 	}
 	if d.HasChange("dns_servers") {
 		_, v := d.GetChange("dns_servers")

--- a/appgate/resource_appgate_identity_provider_saml_test.go
+++ b/appgate/resource_appgate_identity_provider_saml_test.go
@@ -937,6 +937,229 @@ func TestAccSamlIdentityProviderBasic55OrGreater(t *testing.T) {
 	})
 }
 
+func TestAccSamlIdentityProviderUserScripts55OrGreater(t *testing.T) {
+	resourceName := "appgatesdp_saml_identity_provider.saml_test_resource"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSamlIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					c := testAccProvider.Meta().(*Client)
+					c.GetToken()
+					currentVersion := c.ApplianceVersion
+					if currentVersion.LessThan(Appliance55Version) {
+						t.Skip("Test only for 5.5 and above, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5")
+					}
+				},
+				Config: testAccCheckSamlIdentityProviderUserScripts55OrGreater(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "admin_provider", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v6", "6935b379-205d-4fdd-847f-a0b5f14aff53"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "172.17.18.19"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "192.100.111.31"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.2", "192.100.111.32"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "internal.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.company.com/adfs/services/trust"),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"),
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "true"),
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "0"),
+					resource.TestCheckResourceAttr(resourceName, "device_limit_per_user", "44"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.message", "welcome"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.0.mfa_provider_id", "3ae98d53-c520-437f-99e4-451f936e6d2c"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "terraform"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "6"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.attribute_name", "givenName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.claim_name", "firstName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.0.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.attribute_name", "mail"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.claim_name", "emails"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.1.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.attribute_name", "memberOf"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.claim_name", "groups"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.2.list", "true"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.attribute_name", "objectGUID"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.claim_name", "userId"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.3.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.attribute_name", "sAMAccountName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.claim_name", "username"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.4.list", "false"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.attribute_name", "sn"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.claim_name", "lastName"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.5.encrypted", "false"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.claim_name", "antiVirusIsRunning"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.command", "fileSize"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.args", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.name", ""),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.parameters.0.path", "/usr/bin/python3"),
+					resource.TestCheckResourceAttr(resourceName, "on_demand_claim_mappings.0.platform", "desktop.windows.all"),
+					resource.TestCheckResourceAttr(resourceName, "user_scripts.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "user_scripts.0", "appgatesdp_user_claim_script.custom_script", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccSamlIdentityProviderImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckSamlIdentityProviderUserScripts55OrGreater(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_ip_pool" "ip_v6_pool" {
+	ip_pool_name = "default pool v6"
+}
+
+data "appgatesdp_ip_pool" "ip_v4_pool" {
+	ip_pool_name = "default pool v4"
+}
+data "appgatesdp_mfa_provider" "fido" {
+	mfa_provider_name = "Default FIDO2 Provider"
+}
+
+resource "appgatesdp_user_claim_script" "custom_script" {
+	name       = "user claim script"
+	notes      = "This object has been created for test purposes."
+	expression = "return {'posture': 25};"
+	tags = [
+		"developer",
+		"api-created"
+	]
+}
+
+resource "appgatesdp_saml_identity_provider" "saml_test_resource" {
+	depends_on = [
+		appgatesdp_user_claim_script.custom_script
+	]
+	name           = "%s"
+	admin_provider = true
+	ip_pool_v4     = data.appgatesdp_ip_pool.ip_v4_pool.id
+	ip_pool_v6     = data.appgatesdp_ip_pool.ip_v6_pool.id
+	dns_servers = [
+		"172.17.18.19",
+		"192.100.111.31",
+		"192.100.111.32",
+	]
+	dns_search_domains = [
+		"internal.company.com"
+	]
+	redirect_url = "https://saml.company.com"
+	issuer       = "http://adfs-test.company.com/adfs/services/trust"
+	audience     = "Company Appgate SDP"
+
+	user_scripts = [
+		appgatesdp_user_claim_script.custom_script.id
+	]
+
+	provider_certificate = <<-EOF
+		-----BEGIN CERTIFICATE-----
+		MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+		BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+		GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+		MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+		HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+		BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+		+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+		ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+		AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+		gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+		DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+		jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+		eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+		-----END CERTIFICATE-----
+		EOF
+
+	block_local_dns_requests = true
+	device_limit_per_user    = 44
+	on_boarding_two_factor {
+		mfa_provider_id = data.appgatesdp_mfa_provider.fido.id
+		message         = "welcome"
+	}
+	tags = [
+		"terraform",
+
+	]
+	claim_mappings {
+		attribute_name = "objectGUID"
+		claim_name     = "userId"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sAMAccountName"
+		claim_name     = "username"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "givenName"
+		claim_name     = "firstName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "sn"
+		claim_name     = "lastName"
+		encrypted      = false
+		list           = false
+	}
+	claim_mappings {
+		attribute_name = "mail"
+		claim_name     = "emails"
+		encrypted      = false
+		list           = true
+	}
+	claim_mappings {
+		attribute_name = "memberOf"
+		claim_name     = "groups"
+		encrypted      = false
+		list           = true
+	}
+
+	on_demand_claim_mappings {
+		command    = "fileSize"
+		claim_name = "antiVirusIsRunning"
+		parameters {
+		path = "/usr/bin/python3"
+		}
+		platform = "desktop.windows.all"
+	}
+}
+	`, rName)
+}
+
 func testAccCheckSamlIdentityProviderExists(resource string) resource.TestCheckFunc {
 
 	return func(state *terraform.State) error {


### PR DESCRIPTION
add missing attribute, user_scripts to identity_providers this fixes #246

Acceptance tests for 5.5.6-29089-release


<details>

```
make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./appgate -v -count 1 -parallel 20  -timeout 120m
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestLoginInternalServerError
--- PASS: TestLoginInternalServerError (0.00s)
=== RUN   TestClient
=== RUN   TestClient/test_before_5.4
2022/08/09 16:58:15 [DEBUG] Login OK
=== RUN   TestClient/test_5.4_login
2022/08/09 16:58:15 [DEBUG] Login OK
=== RUN   TestClient/invalid_client_version
=== RUN   TestClient/500_login_response
2022/08/09 16:58:15 [DEBUG] Login failed, controller not responding, got HTTP 500
2022/08/09 16:58:16 [DEBUG] Login failed, controller not responding, got HTTP 500
=== RUN   TestClient/502_login_response
2022/08/09 16:58:16 [DEBUG] Login failed, controller not responding, got HTTP 502
2022/08/09 16:58:17 [DEBUG] Login failed, controller not responding, got HTTP 502
=== RUN   TestClient/503_login_response
2022/08/09 16:58:17 [DEBUG] Login failed, controller not responding, got HTTP 503
2022/08/09 16:58:17 [DEBUG] Login failed, controller not responding, got HTTP 503
=== RUN   TestClient/406_login_response
=== RUN   TestClient/test_with_invalid_pem
=== RUN   TestClient/test_with_pem_file
2022/08/09 16:58:17 [DEBUG] Login OK
--- PASS: TestClient (1.62s)
    --- PASS: TestClient/test_before_5.4 (0.01s)
    --- PASS: TestClient/test_5.4_login (0.00s)
    --- PASS: TestClient/invalid_client_version (0.00s)
    --- PASS: TestClient/500_login_response (0.55s)
    --- PASS: TestClient/502_login_response (0.58s)
    --- PASS: TestClient/503_login_response (0.47s)
    --- PASS: TestClient/406_login_response (0.00s)
    --- PASS: TestClient/test_with_invalid_pem (0.00s)
    --- PASS: TestClient/test_with_pem_file (0.00s)
=== RUN   TestConfigValidate
=== RUN   TestConfigValidate/ok_config_minimum_required
=== RUN   TestConfigValidate/invalid_appgate_URL
=== RUN   TestConfigValidate/invalid_token
=== RUN   TestConfigValidate/base64_token
=== RUN   TestConfigValidate/invalid_client_version
=== RUN   TestConfigValidate/invalid_username_password
--- PASS: TestConfigValidate (0.00s)
    --- PASS: TestConfigValidate/ok_config_minimum_required (0.00s)
    --- PASS: TestConfigValidate/invalid_appgate_URL (0.00s)
    --- PASS: TestConfigValidate/invalid_token (0.00s)
    --- PASS: TestConfigValidate/base64_token (0.00s)
    --- PASS: TestConfigValidate/invalid_client_version (0.00s)
    --- PASS: TestConfigValidate/invalid_username_password (0.00s)
=== RUN   TestAccAppgateAdministrativeRoleDataSource
=== PAUSE TestAccAppgateAdministrativeRoleDataSource
=== RUN   TestAccAppgateApplianceCustomizationDataSource
=== PAUSE TestAccAppgateApplianceCustomizationDataSource
=== RUN   TestAccAppgateApplianceSeedDataSource
--- PASS: TestAccAppgateApplianceSeedDataSource (9.04s)
=== RUN   TestAccAppgateCADataSource
--- PASS: TestAccAppgateCADataSource (1.33s)
=== RUN   TestAccAppgateConditionDataSource
--- PASS: TestAccAppgateConditionDataSource (1.92s)
=== RUN   TestAccAppgateEntitlementDataSource
--- PASS: TestAccAppgateEntitlementDataSource (10.16s)
=== RUN   TestAccAppgateGlobalSettingsDataSource
--- PASS: TestAccAppgateGlobalSettingsDataSource (1.91s)
=== RUN   TestAccAppgateIdentityProviderDataSource
--- PASS: TestAccAppgateIdentityProviderDataSource (1.99s)
=== RUN   TestAccAppgateIPPoolDataSource
--- PASS: TestAccAppgateIPPoolDataSource (2.10s)
=== RUN   TestAccAppgateLocalUserDataSource
--- PASS: TestAccAppgateLocalUserDataSource (2.09s)
=== RUN   TestAccAppgateMfaProviderDataSource
=== PAUSE TestAccAppgateMfaProviderDataSource
=== RUN   TestAccAppgateTrustedCertificateDataSource
=== PAUSE TestAccAppgateTrustedCertificateDataSource
=== RUN   TestAccAppgateUserClaimScriptataSource
=== PAUSE TestAccAppgateUserClaimScriptataSource
=== RUN   TestResourceExampleInstanceStateUpgradeV0
=== RUN   TestResourceExampleInstanceStateUpgradeV0/missing_state
=== RUN   TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level
=== RUN   TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing
--- PASS: TestResourceExampleInstanceStateUpgradeV0 (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/missing_state (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/move_device_limit_per_user_to_root_level (0.00s)
    --- PASS: TestResourceExampleInstanceStateUpgradeV0/5.4_do_nothing (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccadministrativeRoleBasic
=== PAUSE TestAccadministrativeRoleBasic
=== RUN   TestAccadministrativeRoleWithScope
=== PAUSE TestAccadministrativeRoleWithScope
=== RUN   TestAccadministrativeMultiplePrivilegesValidation
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation
=== RUN   TestAccadministrativeMultiplePrivilegesValidation52
=== PAUSE TestAccadministrativeMultiplePrivilegesValidation52
=== RUN   TestAccApplianceCustomizationBasic
=== PAUSE TestAccApplianceCustomizationBasic
=== RUN   TestAccApplianceBasicController
--- PASS: TestAccApplianceBasicController (9.45s)
=== RUN   TestAccApplianceConnector
=== PAUSE TestAccApplianceConnector
=== RUN   TestAccApplianceBasicGateway
=== PAUSE TestAccApplianceBasicGateway
=== RUN   TestAccApplianceBasicControllerWithoutOverrideSPA
=== PAUSE TestAccApplianceBasicControllerWithoutOverrideSPA
=== RUN   TestAccApplianceBasicControllerOverriderSPADisabled
=== PAUSE TestAccApplianceBasicControllerOverriderSPADisabled
=== RUN   TestAccAppliancePortalSetup
=== PAUSE TestAccAppliancePortalSetup
=== RUN   TestAccApplianceAdminInterfaceAddRemove
=== PAUSE TestAccApplianceAdminInterfaceAddRemove
=== RUN   TestAccApplianceLogServerFunction
--- PASS: TestAccApplianceLogServerFunction (6.46s)
=== RUN   TestAccApplianceLogForwarderElastic55
=== PAUSE TestAccApplianceLogForwarderElastic55
=== RUN   TestAccBlacklistUserBasic
=== PAUSE TestAccBlacklistUserBasic
=== RUN   TestAccClientConnectionsBasic
--- PASS: TestAccClientConnectionsBasic (1.92s)
=== RUN   TestAccClientProfileBasic
--- PASS: TestAccClientProfileBasic (39.03s)
=== RUN   TestAccConditionBasic
=== PAUSE TestAccConditionBasic
=== RUN   TestAccConditionFixedID
=== PAUSE TestAccConditionFixedID
=== RUN   TestAccCriteriaScriptBasic
=== PAUSE TestAccCriteriaScriptBasic
=== RUN   TestAccDeviceScriptBasic
=== PAUSE TestAccDeviceScriptBasic
=== RUN   TestAccEntitlementScriptBasic
=== PAUSE TestAccEntitlementScriptBasic
=== RUN   TestAccEntitlementBasicPing
=== PAUSE TestAccEntitlementBasicPing
=== RUN   TestAccEntitlementBasicWithMonitor
=== PAUSE TestAccEntitlementBasicWithMonitor
=== RUN   TestAccEntitlementUpdateActionOrder
=== PAUSE TestAccEntitlementUpdateActionOrder
=== RUN   TestAccEntitlementUpdateActionHostOrder
=== PAUSE TestAccEntitlementUpdateActionHostOrder
=== RUN   TestAccEntitlementUpdateActionPortsSetOrder
=== PAUSE TestAccEntitlementUpdateActionPortsSetOrder
=== RUN   TestAccGlobalSettingsBasic
--- PASS: TestAccGlobalSettingsBasic (2.10s)
=== RUN   TestAccGlobalSettings54ProfileHostname
=== PAUSE TestAccGlobalSettings54ProfileHostname
=== RUN   TestAccConnectorIdentityProviderBasic
--- PASS: TestAccConnectorIdentityProviderBasic (2.90s)
=== RUN   TestAccLdapCertificateIdentityProvidervBasic
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic
=== RUN   TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== PAUSE TestAccLdapCertificateIdentityProvidervBasic55OrGreater
=== RUN   TestAccLdapIdentityProviderBasic
=== PAUSE TestAccLdapIdentityProviderBasic
=== RUN   TestAccLdapIdentityProviderBasic55OrGreater
=== PAUSE TestAccLdapIdentityProviderBasic55OrGreater
=== RUN   TestAccLocalDatabaseIdentityProviderBasic
--- PASS: TestAccLocalDatabaseIdentityProviderBasic (3.02s)
=== RUN   TestAccRadiusIdentityProviderBasic
=== PAUSE TestAccRadiusIdentityProviderBasic
=== RUN   TestAccRadiusIdentityProviderBasic55OrGreater
=== PAUSE TestAccRadiusIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderBasic
=== PAUSE TestAccSamlIdentityProviderBasic
=== RUN   TestAccSamlIdentityProviderBasic55OrGreater
=== PAUSE TestAccSamlIdentityProviderBasic55OrGreater
=== RUN   TestAccSamlIdentityProviderUserScripts55OrGreater
=== PAUSE TestAccSamlIdentityProviderUserScripts55OrGreater
=== RUN   TestAccIPPoolBasic
=== PAUSE TestAccIPPoolBasic
=== RUN   TestAccIPPoolV6
=== PAUSE TestAccIPPoolV6
=== RUN   TestAccLocalUserBasic
=== PAUSE TestAccLocalUserBasic
=== RUN   TestAccMfaProviderBasic
=== PAUSE TestAccMfaProviderBasic
=== RUN   TestAccAdminMfaSettingsBasic
=== PAUSE TestAccAdminMfaSettingsBasic
=== RUN   TestAccPolicyBasic
=== PAUSE TestAccPolicyBasic
=== RUN   TestAccPolicyClientSettings55
=== PAUSE TestAccPolicyClientSettings55
=== RUN   TestAccPolicyDnsSettings55
=== PAUSE TestAccPolicyDnsSettings55
=== RUN   TestAccRingfenceRuleBasicICMP
=== PAUSE TestAccRingfenceRuleBasicICMP
=== RUN   TestAccRingfenceRuleBasicTCP
=== PAUSE TestAccRingfenceRuleBasicTCP
=== RUN   TestAccSiteBasic
=== PAUSE TestAccSiteBasic
=== RUN   TestAccSiteBasicAwsResolverWithoutSecret
=== PAUSE TestAccSiteBasicAwsResolverWithoutSecret
=== RUN   TestAccSiteBasicAwsResolverresolveWithMasterCredentials
=== PAUSE TestAccSiteBasicAwsResolverresolveWithMasterCredentials
=== RUN   TestAccSite55Attributes
=== PAUSE TestAccSite55Attributes
=== RUN   TestAccSiteVPNRouteVia
--- PASS: TestAccSiteVPNRouteVia (5.74s)
=== RUN   TestAccSiteVPNRouteViaIpv4Only
--- PASS: TestAccSiteVPNRouteViaIpv4Only (5.77s)
=== RUN   TestAccTrustedCertificateBasic
=== PAUSE TestAccTrustedCertificateBasic
=== RUN   TestAccUserClaimScriptBasic
=== PAUSE TestAccUserClaimScriptBasic
=== CONT  TestAccAppgateAdministrativeRoleDataSource
=== CONT  TestAccMfaProviderBasic
=== CONT  TestAccSiteBasic
=== CONT  TestAccSite55Attributes
=== CONT  TestAccSiteBasicAwsResolverresolveWithMasterCredentials
=== CONT  TestAccDeviceScriptBasic
=== CONT  TestAccUserClaimScriptBasic
=== CONT  TestAccCriteriaScriptBasic
=== CONT  TestAccPolicyDnsSettings55
=== CONT  TestAccSiteBasicAwsResolverWithoutSecret
=== CONT  TestAccTrustedCertificateBasic
=== CONT  TestAccRingfenceRuleBasicTCP
=== CONT  TestAccPolicyClientSettings55
=== CONT  TestAccLocalUserBasic
=== CONT  TestAccApplianceConnector
=== CONT  TestAccApplianceAdminInterfaceAddRemove
=== CONT  TestAccPolicyBasic
=== CONT  TestAccAdminMfaSettingsBasic
=== CONT  TestAccRingfenceRuleBasicICMP
=== CONT  TestAccApplianceBasicControllerOverriderSPADisabled
--- PASS: TestAccPolicyBasic (4.71s)
=== CONT  TestAccApplianceCustomizationBasic
--- PASS: TestAccAppgateAdministrativeRoleDataSource (4.78s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
--- PASS: TestAccAdminMfaSettingsBasic (4.81s)
=== CONT  TestAccadministrativeMultiplePrivilegesValidation
--- PASS: TestAccRingfenceRuleBasicICMP (5.19s)
=== CONT  TestAccadministrativeRoleWithScope
=== CONT  TestAccadministrativeMultiplePrivilegesValidation52
    resource_appgate_administrative_role_test.go:272: Test is only for 5.2, privileges.target OnBoardedDevice
--- PASS: TestAccRingfenceRuleBasicTCP (5.34s)
=== CONT  TestAccadministrativeRoleBasic
--- PASS: TestAccSiteBasicAwsResolverWithoutSecret (5.35s)
=== CONT  TestAccAppgateUserClaimScriptataSource
--- SKIP: TestAccadministrativeMultiplePrivilegesValidation52 (0.61s)
=== CONT  TestAccAppgateTrustedCertificateDataSource
--- PASS: TestAccLocalUserBasic (5.59s)
=== CONT  TestAccApplianceBasicControllerWithoutOverrideSPA
--- PASS: TestAccTrustedCertificateBasic (5.60s)
=== CONT  TestAccApplianceBasicGateway
--- PASS: TestAccDeviceScriptBasic (5.61s)
=== CONT  TestAccAppgateMfaProviderDataSource
--- PASS: TestAccCriteriaScriptBasic (5.81s)
=== CONT  TestAccAppgateApplianceCustomizationDataSource
--- PASS: TestAccMfaProviderBasic (6.02s)
=== CONT  TestAccLdapIdentityProviderBasic
    resource_appgate_identity_provider_ldap_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapIdentityProviderBasic (0.55s)
=== CONT  TestAccIPPoolV6
--- PASS: TestAccApplianceConnector (8.40s)
=== CONT  TestAccIPPoolBasic
--- PASS: TestAccApplianceBasicControllerOverriderSPADisabled (8.52s)
=== CONT  TestAccSamlIdentityProviderUserScripts55OrGreater
--- PASS: TestAccUserClaimScriptBasic (10.12s)
=== CONT  TestAccSamlIdentityProviderBasic55OrGreater
--- PASS: TestAccPolicyClientSettings55 (10.18s)
=== CONT  TestAccSamlIdentityProviderBasic
--- PASS: TestAccAppgateUserClaimScriptataSource (5.06s)
=== CONT  TestAccRadiusIdentityProviderBasic55OrGreater
=== CONT  TestAccSamlIdentityProviderBasic
    resource_appgate_identity_provider_saml_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccSamlIdentityProviderBasic (0.74s)
=== CONT  TestAccRadiusIdentityProviderBasic
--- PASS: TestAccAppgateTrustedCertificateDataSource (5.70s)
=== CONT  TestAccLdapIdentityProviderBasic55OrGreater
--- PASS: TestAccAppgateApplianceCustomizationDataSource (5.29s)
=== CONT  TestAccAppliancePortalSetup
--- PASS: TestAccadministrativeMultiplePrivilegesValidation (6.37s)
=== CONT  TestAccEntitlementUpdateActionHostOrder
--- PASS: TestAccAppgateMfaProviderDataSource (5.62s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic55OrGreater
--- PASS: TestAccadministrativeRoleBasic (5.96s)
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
=== CONT  TestAccRadiusIdentityProviderBasic
    resource_appgate_identity_provider_radius_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- PASS: TestAccSite55Attributes (11.51s)
=== CONT  TestAccGlobalSettings54ProfileHostname
--- SKIP: TestAccRadiusIdentityProviderBasic (0.62s)
=== CONT  TestAccEntitlementUpdateActionPortsSetOrder
=== CONT  TestAccLdapCertificateIdentityProvidervBasic
    resource_appgate_identity_provider_ldap_certificate_test.go:26: Test only for 5.4 and below, on_boarding_two_factor.0.device_limit_per_user updated behaviour in > 5.5
--- SKIP: TestAccLdapCertificateIdentityProvidervBasic (0.77s)
=== CONT  TestAccEntitlementBasicWithMonitor
--- PASS: TestAccIPPoolV6 (5.69s)
=== CONT  TestAccEntitlementUpdateActionOrder
--- PASS: TestAccadministrativeRoleWithScope (7.72s)
=== CONT  TestAccEntitlementBasicPing
--- PASS: TestAccApplianceBasicGateway (8.00s)
=== CONT  TestAccConditionBasic
--- PASS: TestAccApplianceCustomizationBasic (9.67s)
=== CONT  TestAccConditionFixedID
--- PASS: TestAccIPPoolBasic (6.17s)
=== CONT  TestAccEntitlementScriptBasic
--- PASS: TestAccApplianceAdminInterfaceAddRemove (14.74s)
=== CONT  TestAccBlacklistUserBasic
--- PASS: TestAccApplianceBasicControllerWithoutOverrideSPA (9.26s)
=== CONT  TestAccApplianceLogForwarderElastic55
--- PASS: TestAccSiteBasicAwsResolverresolveWithMasterCredentials (15.42s)
--- PASS: TestAccPolicyDnsSettings55 (16.25s)
--- PASS: TestAccGlobalSettings54ProfileHostname (5.57s)
--- PASS: TestAccSamlIdentityProviderUserScripts55OrGreater (9.36s)
--- PASS: TestAccBlacklistUserBasic (3.57s)
--- PASS: TestAccConditionBasic (4.71s)
--- PASS: TestAccSamlIdentityProviderBasic55OrGreater (8.91s)
--- PASS: TestAccRadiusIdentityProviderBasic55OrGreater (8.70s)
--- PASS: TestAccEntitlementScriptBasic (4.57s)
--- PASS: TestAccConditionFixedID (4.76s)
--- PASS: TestAccLdapCertificateIdentityProvidervBasic55OrGreater (8.08s)
--- PASS: TestAccLdapIdentityProviderBasic55OrGreater (8.30s)
--- PASS: TestAccEntitlementBasicPing (6.99s)
--- PASS: TestAccApplianceLogForwarderElastic55 (6.60s)
--- PASS: TestAccEntitlementUpdateActionHostOrder (11.65s)
--- PASS: TestAccEntitlementUpdateActionPortsSetOrder (11.72s)
--- PASS: TestAccEntitlementUpdateActionOrder (11.05s)
--- PASS: TestAccEntitlementBasicWithMonitor (11.24s)
--- PASS: TestAccSiteBasic (23.86s)
--- PASS: TestAccAppliancePortalSetup (51.65s)
PASS
ok  	github.com/appgate/terraform-provider-appgatesdp/appgate	171.309s
```

</details>