### PR TITLE
appliance controller activation revisited

### DIFF
--- a/appgate/resource_appgate_appliance_controller.go
+++ b/appgate/resource_appgate_appliance_controller.go
@@ -26,9 +26,9 @@ func resourceAppgateApplianceControllerActivation() *schema.Resource {
 		DeleteContext: resourceAppgateApplianceControllerActivationDelete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(45 * time.Minute),
+			Update: schema.DefaultTimeout(45 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
 		},
 		Schema: func() map[string]*schema.Schema {
 			s := map[string]*schema.Schema{

--- a/appgate/resource_appgate_appliance_controller.go
+++ b/appgate/resource_appgate_appliance_controller.go
@@ -96,7 +96,7 @@ func resourceAppgateApplianceControllerActivationCreate(ctx context.Context, d *
 		appliance.SetAdminInterface(ainterface)
 	}
 
-	retryErr := resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
+	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(*appliance).Authorization(token).Execute()
 		if err != nil {
 			return resource.NonRetryableError(prettyPrintAPIError(err))
@@ -208,7 +208,7 @@ func resourceAppgateApplianceControllerActivationUpdate(ctx context.Context, d *
 	if ctrl.GetEnabled() == true {
 		state = ApplianceStateControllerReady
 	}
-	retryErr := resource.Retry(d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
+	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {
 		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(*appliance).Authorization(token).Execute()
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Could not update appliance %w", prettyPrintAPIError(err)))
@@ -252,7 +252,7 @@ func resourceAppgateApplianceControllerActivationDelete(ctx context.Context, d *
 	c.SetEnabled(false)
 	appliance.SetController(c)
 
-	retryErr := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
+	retryErr := resource.RetryContext(ctx, d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, _, err := api.AppliancesIdPut(ctx, id).Appliance(*appliance).Authorization(token).Execute()
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("Could not update appliance when disable controller on %s %w", appliance.Name, prettyPrintAPIError(err)))

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -394,8 +394,9 @@ func waitForApplianceState(ctx context.Context, meta interface{}, applianceID, s
 		if appliance.GetId() != applianceID {
 			return fmt.Errorf("could not find appliance %q in stats list", applianceID)
 		}
-		if appliance.GetState() == state {
-			log.Printf("[DEBUG] Appliance %q reached expected state %s", applianceID, state)
+		got := appliance.GetState()
+		log.Printf("[DEBUG] Appliance %s state is %s want state %s", applianceID, got, state)
+		if got == state {
 			return nil
 		}
 		return fmt.Errorf("appliance %q is in state %s expected %s", applianceID, appliance.GetState(), state)


### PR DESCRIPTION
This PR includes some internal improvements when creating, updating, and deleting `appgatesdp_appliance_controller_activation` 
to avoid getting in a false negative state as shown in #258 

The practitioner will only be prompted with a warning message if the appliance state check fails or exceed timeout during destroy. It's no longer a fatal error.

This PR also includes some maintenance work, such as:
- replace deprecated function Retry() with RetryContext()
- Updated debug logs
- extended usage of [diags](https://www.terraform.io/plugin/framework/diagnostics)
- Updated default timeout values from 15 to 45 minutes for create,update, and delete.