### PR TITLE
bumped version to 1.0.1 since 0.9.0 does not exist

### DIFF
--- a/website/docs/guides/version_compatibility.markdown
+++ b/website/docs/guides/version_compatibility.markdown
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     appgatesdp = {
       source = "appgate/appgatesdp"
-      version = "0.9.0"
+      version = "1.0.1"
     }
   }
 }


### PR DESCRIPTION
version = "0.9.0"   resulted in the following error on "terraform init" since that version does not exist on registry.terraform.io

Initializing provider plugins...
- Finding appgate/appgatesdp versions matching "0.9.0"... ╷
│ Error: Failed to query available provider packages │
│ Could not retrieve the list of available versions for provider appgate/appgatesdp: no available releases match the given constraints 0.9.0