### PR TITLE
bump to v18

### DIFF
--- a/appgate/config.go
+++ b/appgate/config.go
@@ -158,6 +158,8 @@ func guessVersion(clientVersion int) (*version.Version, error) {
 		return version.NewVersion("5.5.0+estimated")
 	case Version17:
 		return version.NewVersion("6.0.0+estimated")
+	case Version18:
+		return version.NewVersion("6.1.0+estimated")
 
 	}
 	return nil, fmt.Errorf("could not determine appliance version with client version %d", clientVersion)

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-version"
 )

--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"
 )

--- a/appgate/data_source_appgate_administrative_role.go
+++ b/appgate/data_source_appgate_administrative_role.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/appgate/data_source_appgate_appliance.go
+++ b/appgate/data_source_appgate_appliance.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/appgate/data_source_appgate_appliance_customization.go
+++ b/appgate/data_source_appgate_appliance_customization.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_appliance_seed.go
+++ b/appgate/data_source_appgate_appliance_seed.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_certificate_authority.go
+++ b/appgate/data_source_appgate_certificate_authority.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_condition.go
+++ b/appgate/data_source_appgate_condition.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_criteria_script.go
+++ b/appgate/data_source_appgate_criteria_script.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_device_script.go
+++ b/appgate/data_source_appgate_device_script.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_entitlement.go
+++ b/appgate/data_source_appgate_entitlement.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/appgate/data_source_appgate_entitlement_script.go
+++ b/appgate/data_source_appgate_entitlement_script.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_global_settings.go
+++ b/appgate/data_source_appgate_global_settings.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_ip_pool.go
+++ b/appgate/data_source_appgate_ip_pool.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_local_user.go
+++ b/appgate/data_source_appgate_local_user.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_mfa_provider.go
+++ b/appgate/data_source_appgate_mfa_provider.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_policy.go
+++ b/appgate/data_source_appgate_policy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_ringfence_rule.go
+++ b/appgate/data_source_appgate_ringfence_rule.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_site.go
+++ b/appgate/data_source_appgate_site.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_trusted_certificate.go
+++ b/appgate/data_source_appgate_trusted_certificate.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/data_source_appgate_user_claim_script.go
+++ b/appgate/data_source_appgate_user_claim_script.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/identity_provider.go
+++ b/appgate/identity_provider.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 
 	"github.com/hashicorp/go-version"

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -23,6 +23,7 @@ const (
 	Version15 = 15
 	Version16 = 16
 	Version17 = 17
+	Version18 = 18
 	// DefaultClientVersion is the latest support version of appgate sdp client that is supported.
 	// its not recommended to change this value.
 	DefaultClientVersion = Version17
@@ -37,6 +38,7 @@ var (
 		Version15: "5.4.0",
 		Version16: "5.5.0",
 		Version17: "6.0.0",
+		Version18: "6.1.0",
 	}
 
 	Appliance53Version, _ = version.NewVersion(ApplianceVersionMap[Version14])

--- a/appgate/resource_appgate_administrative_role.go
+++ b/appgate/resource_appgate_administrative_role.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 
 	"github.com/hashicorp/go-version"

--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-version"

--- a/appgate/resource_appgate_appliance_controller.go
+++ b/appgate/resource_appgate_appliance_controller.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/appgate/resource_appgate_appliance_customization.go
+++ b/appgate/resource_appgate_appliance_customization.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_blacklist_user.go
+++ b/appgate/resource_appgate_blacklist_user.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_client_connections.go
+++ b/appgate/resource_appgate_client_connections.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_client_profile.go
+++ b/appgate/resource_appgate_client_profile.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/appgate/resource_appgate_condition.go
+++ b/appgate/resource_appgate_condition.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/appgate/resource_appgate_criteria_script.go
+++ b/appgate/resource_appgate_criteria_script.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_device_script.go
+++ b/appgate/resource_appgate_device_script.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/appgate/resource_appgate_entitlement.go
+++ b/appgate/resource_appgate_entitlement.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/appgate/resource_appgate_entitlement_script.go
+++ b/appgate/resource_appgate_entitlement_script.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_connector.go
+++ b/appgate/resource_appgate_identity_provider_connector.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -53,7 +53,7 @@ func resourceAppgateLdapProviderRuleCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %w", identityProviderLdap, err)
 	}
 
-	args := openapi.NewLdapProviderWithDefaults()
+	args := openapi.LdapProvider{}
 
 	if currentVersion.LessThan(Appliance55Version) {
 		args.DeviceLimitPerUser = nil
@@ -138,7 +138,7 @@ func resourceAppgateLdapProviderRuleCreate(d *schema.ResourceData, meta interfac
 	}
 
 	request := api.IdentityProvidersPost(ctx)
-	p, _, err := request.Body(*args).Authorization(token).Execute()
+	p, _, err := request.Body(args).Authorization(token).Execute()
 	if err != nil {
 		return fmt.Errorf("Could not create %s provider %w", identityProviderLdap, prettyPrintAPIError(err))
 	}

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -74,7 +74,7 @@ func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, me
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %w", identityProviderLdapCertificate, err)
 	}
 
-	args := openapi.NewLdapCertificateProviderWithDefaults()
+	args := openapi.LdapCertificateProvider{}
 
 	if currentVersion.LessThan(Appliance55Version) {
 		args.DeviceLimitPerUser = nil
@@ -179,7 +179,7 @@ func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, me
 		args.SetSkipX509ExternalChecks(v.(bool))
 	}
 	request := api.IdentityProvidersPost(ctx)
-	p, _, err := request.Body(*args).Authorization(token).Execute()
+	p, _, err := request.Body(args).Authorization(token).Execute()
 	if err != nil {
 		return fmt.Errorf("Could not create %s provider %w", identityProviderLdapCertificate, prettyPrintAPIError(err))
 	}

--- a/appgate/resource_appgate_identity_provider_local_database.go
+++ b/appgate/resource_appgate_identity_provider_local_database.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -82,7 +82,7 @@ func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interf
 	if err != nil {
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %w", identityProviderRadius, err)
 	}
-	args := openapi.NewRadiusProviderWithDefaults()
+	args := openapi.RadiusProvider{}
 	// base
 	if currentVersion.LessThan(Appliance55Version) {
 		args.DeviceLimitPerUser = nil
@@ -149,7 +149,7 @@ func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interf
 	}
 
 	request := api.IdentityProvidersPost(ctx)
-	p, _, err := request.Body(*args).Authorization(token).Execute()
+	p, _, err := request.Body(args).Authorization(token).Execute()
 	if err != nil {
 		return fmt.Errorf("Could not create %s provider %w", identityProviderRadius, prettyPrintAPIError(err))
 	}

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -76,7 +76,7 @@ func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Failed to read and create basic identity provider for %s %w", identityProviderSaml, err)
 	}
 
-	args := openapi.NewSamlProviderWithDefaults()
+	args := openapi.SamlProvider{}
 	if currentVersion.LessThan(Appliance55Version) {
 		args.DeviceLimitPerUser = nil
 	}
@@ -142,7 +142,7 @@ func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interfac
 		args.SetForceAuthn(v.(bool))
 	}
 	request := api.IdentityProvidersPost(ctx)
-	p, _, err := request.Body(*args).Authorization(token).Execute()
+	p, _, err := request.Body(args).Authorization(token).Execute()
 	if err != nil {
 		return fmt.Errorf("Could not create %s provider %w", identityProviderSaml, prettyPrintAPIError(err))
 	}

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_ip_pool.go
+++ b/appgate/resource_appgate_ip_pool.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -125,13 +125,13 @@ func resourceAppgateIPPoolCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceAppgateIPPoolRead(d, meta)
 }
 
-func readIPPoolRangesFromConfig(ranges []interface{}) ([]openapi.IpPoolAllOfRanges, error) {
-	result := make([]openapi.IpPoolAllOfRanges, 0)
+func readIPPoolRangesFromConfig(ranges []interface{}) ([]openapi.IpPoolRangeInner, error) {
+	result := make([]openapi.IpPoolRangeInner, 0)
 	for _, ipRange := range ranges {
 		if ipRange == nil {
 			continue
 		}
-		r := openapi.IpPoolAllOfRanges{}
+		r := openapi.IpPoolRangeInner{}
 		raw := ipRange.(map[string]interface{})
 		if v, ok := raw["first"]; ok {
 			r.SetFirst(v.(string))
@@ -178,7 +178,7 @@ func resourceAppgateIPPoolRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func flattenIPPoolRanges(in []openapi.IpPoolAllOfRanges) []map[string]interface{} {
+func flattenIPPoolRanges(in []openapi.IpPoolRangeInner) []map[string]interface{} {
 	var out = make([]map[string]interface{}, len(in), len(in))
 	for i, v := range in {
 		m := make(map[string]interface{})

--- a/appgate/resource_appgate_license.go
+++ b/appgate/resource_appgate_license.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_local_user.go
+++ b/appgate/resource_appgate_local_user.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -78,7 +78,7 @@ func resourceAppgateLocalUserCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	api := meta.(*Client).API.LocalUsersApi
-	args := openapi.NewLocalUserWithDefaults()
+	args := openapi.LocalUsersGetRequest{}
 	if v, ok := d.GetOk("local_user_id"); ok {
 		args.SetId(v.(string))
 	}
@@ -113,10 +113,8 @@ func resourceAppgateLocalUserCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		args.SetLockStart(*t)
 	}
-	request := api.LocalUsersPost(context.TODO())
-	request = request.LocalUser(*args)
 
-	localUser, _, err := request.Authorization(token).Execute()
+	localUser, _, err := api.LocalUsersPost(context.Background()).LocalUsersGetRequest(args).Authorization(token).Execute()
 	if err != nil {
 		return fmt.Errorf("Could not create Local user %w", prettyPrintAPIError(err))
 	}

--- a/appgate/resource_appgate_mfa_provider.go
+++ b/appgate/resource_appgate_mfa_provider.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_policy.go
+++ b/appgate/resource_appgate_policy.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/appgate/resource_appgate_ringfence_rule.go
+++ b/appgate/resource_appgate_ringfence_rule.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/appgate/resource_appgate_site_test.go
+++ b/appgate/resource_appgate_site_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccSiteBasic(t *testing.T) {
 	resourceName := "appgatesdp_site.test_site"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSiteDestroy,
@@ -606,7 +606,7 @@ func TestAccSiteBasicAwsResolverWithoutSecret(t *testing.T) {
 	context := map[string]interface{}{
 		"name": rName,
 	}
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSiteDestroy,
@@ -706,7 +706,7 @@ func TestAccSiteBasicAwsResolverresolveWithMasterCredentials(t *testing.T) {
 	context := map[string]interface{}{
 		"name": rName,
 	}
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSiteDestroy,
@@ -976,7 +976,7 @@ func testAccSiteBasicAwsResolverConfiWithMasterCredentialsUpdated(context map[st
 func TestAccSite55Attributes(t *testing.T) {
 	resourceName := "appgatesdp_site.test_site"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSiteDestroy,
@@ -1729,7 +1729,7 @@ resource "appgatesdp_site" "d_test_site" {
 func TestAccSiteNameResolver6(t *testing.T) {
 	resourceName := "appgatesdp_site.test_site"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckSiteDestroy,

--- a/appgate/resource_appgate_trusted_certificate.go
+++ b/appgate/resource_appgate_trusted_certificate.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 

--- a/appgate/resource_appgate_user_claim_script.go
+++ b/appgate/resource_appgate_user_claim_script.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/appgate/sdp-api-client-go/api/v17/openapi"
+	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
 	"github.com/appgate/terraform-provider-appgatesdp/appgate/hashcode"
 	"github.com/cenkalti/backoff/v4"
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20220726122858-aa55b5830bca
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20221209134722-b6de3b668031
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa h1:mBg
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846 h1:Ct3XqrdnMHHG2Rc+kDF40KcS48bbE84ci8hKGDgui94=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda h1:WOsCR+P/RBRvEintAh7nunYElC8nSgLa5OKicw6h3Eo=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/appgate/sdp-api-client-go v1.0.7-0.20221129135017-7f177be07056 h1:tOK
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221129135017-7f177be07056/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa h1:mBg4CROLP5FAZkdYsynLXAhidXOr/5yJc8sTnFxcO9U=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846 h1:Ct3XqrdnMHHG2Rc+kDF40KcS48bbE84ci8hKGDgui94=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846 h1:Ct3
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221130131121-c15612f98846/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda h1:WOsCR+P/RBRvEintAh7nunYElC8nSgLa5OKicw6h3Eo=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221208151033-47389c78ceda/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221209134722-b6de3b668031 h1:16MbAhBU9VTQWvnoS3HfhvXf96ZcaFUyj2pQRtaPaLo=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221209134722-b6de3b668031/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,12 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220726122858-aa55b5830bca h1:4rkzM5MTda4Pnw9w4St0JWX4mkfcRaPrNDgH4fAGEUc=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20220726122858-aa55b5830bca/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129132203-5f5e6b351afe h1:sSrHxlCNmbUlKuofqS9xjXbkY7qj694ooOfpf4UVnX4=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129132203-5f5e6b351afe/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129135017-7f177be07056 h1:tOKIph5wCwTDQg5/tAlL2quI+y7iSbPcwaqb2is+HLs=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129135017-7f177be07056/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa h1:mBg4CROLP5FAZkdYsynLXAhidXOr/5yJc8sTnFxcO9U=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20221129150214-cead6a7595fa/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=


### PR DESCRIPTION
bump sdp-api-client-go from v17 to v18

depends on https://github.com/appgate/sdp-api-client-go/pull/16/

this PR does **not** include any new attributes/resource from 6.1, that will come later. 