### PR TITLE
identity providers network_inactivity_timeout_enabled

### DIFF
--- a/appgate/identity_provider.go
+++ b/appgate/identity_provider.go
@@ -3,6 +3,7 @@ package appgate
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
@@ -22,6 +23,10 @@ const (
 	identityProviderConnector       = "Connector"
 	builtinProviderLocal            = "local"
 	builtinProviderConnector        = "Connector"
+)
+
+var (
+	ErrNetworkInactivityTimeoutEnabled = errors.New("network_inactivity_timeout_enabled is only available in 6.1 or higher")
 )
 
 func identityProviderSchema() map[string]*schema.Schema {
@@ -96,6 +101,11 @@ func identityProviderSchema() map[string]*schema.Schema {
 
 			"inactivity_timeout_minutes": {
 				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+			},
+			"network_inactivity_timeout_enabled": {
+				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
 			},
@@ -445,6 +455,9 @@ func readProviderFromConfig(d *schema.ResourceData, provider openapi.Configurabl
 
 	if v, ok := d.GetOk("inactivity_timeout_minutes"); ok {
 		provider.SetInactivityTimeoutMinutes(int32(v.(int)))
+	}
+	if v, ok := d.GetOk("network_inactivity_timeout_enabled"); ok {
+		provider.SetNetworkInactivityTimeoutEnabled(v.(bool))
 	}
 	if v, ok := d.GetOk("ip_pool_v4"); ok {
 		provider.SetIpPoolV4(v.(string))

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -77,6 +77,12 @@ func resourceAppgateLdapProviderRuleCreate(d *schema.ResourceData, meta interfac
 	if provider.InactivityTimeoutMinutes != nil {
 		args.SetInactivityTimeoutMinutes(*provider.InactivityTimeoutMinutes)
 	}
+	if provider.NetworkInactivityTimeoutEnabled != nil {
+		if currentVersion.LessThan(Appliance61Version) {
+			return ErrNetworkInactivityTimeoutEnabled
+		}
+		args.SetNetworkInactivityTimeoutEnabled(provider.GetNetworkInactivityTimeoutEnabled())
+	}
 	if provider.IpPoolV4 != nil {
 		args.SetIpPoolV4(*provider.IpPoolV4)
 	}
@@ -182,6 +188,7 @@ func resourceAppgateLdapProviderRuleRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("inactivity_timeout_minutes", ldap.GetInactivityTimeoutMinutes())
+	d.Set("network_inactivity_timeout_enabled", ldap.GetNetworkInactivityTimeoutEnabled())
 	if v, ok := ldap.GetIpPoolV4Ok(); ok {
 		d.Set("ip_pool_v4", *v)
 	}
@@ -307,6 +314,9 @@ func resourceAppgateLdapProviderRuleUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("inactivity_timeout_minutes") {
 		originalLdapProvider.SetInactivityTimeoutMinutes(int32(d.Get("inactivity_timeout_minutes").(int)))
+	}
+	if d.HasChange("network_inactivity_timeout_enabled") {
+		originalLdapProvider.SetNetworkInactivityTimeoutEnabled(d.Get("network_inactivity_timeout_enabled").(bool))
 	}
 	if d.HasChange("ip_pool_v4") {
 		originalLdapProvider.SetIpPoolV4(d.Get("ip_pool_v4").(string))

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -98,6 +98,12 @@ func resourceAppgateLdapCertificateProviderRuleCreate(d *schema.ResourceData, me
 	if provider.InactivityTimeoutMinutes != nil {
 		args.SetInactivityTimeoutMinutes(*provider.InactivityTimeoutMinutes)
 	}
+	if provider.NetworkInactivityTimeoutEnabled != nil {
+		if currentVersion.LessThan(Appliance61Version) {
+			return ErrNetworkInactivityTimeoutEnabled
+		}
+		args.SetNetworkInactivityTimeoutEnabled(provider.GetNetworkInactivityTimeoutEnabled())
+	}
 	if provider.IpPoolV4 != nil {
 		args.SetIpPoolV4(*provider.IpPoolV4)
 	}
@@ -224,6 +230,7 @@ func resourceAppgateLdapCertificateProviderRuleRead(d *schema.ResourceData, meta
 	}
 
 	d.Set("inactivity_timeout_minutes", ldap.GetInactivityTimeoutMinutes())
+	d.Set("network_inactivity_timeout_enabled", ldap.GetNetworkInactivityTimeoutEnabled())
 	if v, ok := ldap.GetIpPoolV4Ok(); ok {
 		d.Set("ip_pool_v4", *v)
 	}
@@ -324,6 +331,9 @@ func resourceAppgateLdapCertificateProviderRuleUpdate(d *schema.ResourceData, me
 
 	if d.HasChange("inactivity_timeout_minutes") {
 		originalLdapCertificateProvider.SetInactivityTimeoutMinutes(int32(d.Get("inactivity_timeout_minutes").(int)))
+	}
+	if d.HasChange("network_inactivity_timeout_enabled") {
+		originalLdapCertificateProvider.SetNetworkInactivityTimeoutEnabled(d.Get("network_inactivity_timeout_enabled").(bool))
 	}
 	if d.HasChange("ip_pool_v4") {
 		originalLdapCertificateProvider.SetIpPoolV4(d.Get("ip_pool_v4").(string))

--- a/appgate/resource_appgate_identity_provider_local_database.go
+++ b/appgate/resource_appgate_identity_provider_local_database.go
@@ -116,6 +116,7 @@ func resourceAppgateLocalDatabaseProviderRuleRead(d *schema.ResourceData, meta i
 	}
 
 	d.Set("inactivity_timeout_minutes", localDatabase.GetInactivityTimeoutMinutes())
+	d.Set("network_inactivity_timeout_enabled", localDatabase.GetNetworkInactivityTimeoutEnabled())
 	if v, ok := localDatabase.GetIpPoolV4Ok(); ok {
 		d.Set("ip_pool_v4", *v)
 	}
@@ -185,6 +186,9 @@ func resourceAppgateLocalDatabaseProviderRuleUpdate(d *schema.ResourceData, meta
 
 	if d.HasChange("inactivity_timeout_minutes") {
 		originalLocalDatabaseProvider.SetInactivityTimeoutMinutes(int32(d.Get("inactivity_timeout_minutes").(int)))
+	}
+	if d.HasChange("network_inactivity_timeout_enabled") {
+		originalLocalDatabaseProvider.SetNetworkInactivityTimeoutEnabled(d.Get("network_inactivity_timeout_enabled").(bool))
 	}
 	if d.HasChange("ip_pool_v4") {
 		originalLocalDatabaseProvider.SetIpPoolV4(d.Get("ip_pool_v4").(string))

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -106,6 +106,12 @@ func resourceAppgateRadiusProviderRuleCreate(d *schema.ResourceData, meta interf
 	if provider.InactivityTimeoutMinutes != nil {
 		args.SetInactivityTimeoutMinutes(*provider.InactivityTimeoutMinutes)
 	}
+	if provider.NetworkInactivityTimeoutEnabled != nil {
+		if currentVersion.LessThan(Appliance61Version) {
+			return ErrNetworkInactivityTimeoutEnabled
+		}
+		args.SetNetworkInactivityTimeoutEnabled(provider.GetNetworkInactivityTimeoutEnabled())
+	}
 	if provider.IpPoolV4 != nil {
 		args.SetIpPoolV4(*provider.IpPoolV4)
 	}
@@ -192,6 +198,7 @@ func resourceAppgateRadiusProviderRuleRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.Set("inactivity_timeout_minutes", radius.GetInactivityTimeoutMinutes())
+	d.Set("network_inactivity_timeout_enabled", radius.GetNetworkInactivityTimeoutEnabled())
 	if v, ok := radius.GetIpPoolV4Ok(); ok {
 		d.Set("ip_pool_v4", *v)
 	}
@@ -276,6 +283,9 @@ func resourceAppgateRadiusProviderRuleUpdate(d *schema.ResourceData, meta interf
 
 	if d.HasChange("inactivity_timeout_minutes") {
 		originalRadiusProvider.SetInactivityTimeoutMinutes(int32(d.Get("inactivity_timeout_minutes").(int)))
+	}
+	if d.HasChange("network_inactivity_timeout_enabled") {
+		originalRadiusProvider.SetNetworkInactivityTimeoutEnabled(d.Get("network_inactivity_timeout_enabled").(bool))
 	}
 	if d.HasChange("ip_pool_v4") {
 		originalRadiusProvider.SetIpPoolV4(d.Get("ip_pool_v4").(string))

--- a/appgate/resource_appgate_identity_provider_saml.go
+++ b/appgate/resource_appgate_identity_provider_saml.go
@@ -98,6 +98,12 @@ func resourceAppgateSamlProviderRuleCreate(d *schema.ResourceData, meta interfac
 	if provider.InactivityTimeoutMinutes != nil {
 		args.SetInactivityTimeoutMinutes(*provider.InactivityTimeoutMinutes)
 	}
+	if provider.NetworkInactivityTimeoutEnabled != nil {
+		if currentVersion.LessThan(Appliance61Version) {
+			return ErrNetworkInactivityTimeoutEnabled
+		}
+		args.SetNetworkInactivityTimeoutEnabled(provider.GetNetworkInactivityTimeoutEnabled())
+	}
 	if provider.IpPoolV4 != nil {
 		args.SetIpPoolV4(*provider.IpPoolV4)
 	}
@@ -184,6 +190,7 @@ func resourceAppgateSamlProviderRuleRead(d *schema.ResourceData, meta interface{
 	}
 
 	d.Set("inactivity_timeout_minutes", saml.GetInactivityTimeoutMinutes())
+	d.Set("network_inactivity_timeout_enabled", saml.GetNetworkInactivityTimeoutEnabled())
 	if v, ok := saml.GetIpPoolV4Ok(); ok {
 		d.Set("ip_pool_v4", *v)
 	}
@@ -259,6 +266,9 @@ func resourceAppgateSamlProviderRuleUpdate(d *schema.ResourceData, meta interfac
 
 	if d.HasChange("inactivity_timeout_minutes") {
 		originalSamlProvider.SetInactivityTimeoutMinutes(int32(d.Get("inactivity_timeout_minutes").(int)))
+	}
+	if d.HasChange("network_inactivity_timeout_enabled") {
+		originalSamlProvider.SetNetworkInactivityTimeoutEnabled(d.Get("network_inactivity_timeout_enabled").(bool))
 	}
 	if d.HasChange("ip_pool_v4") {
 		originalSamlProvider.SetIpPoolV4(d.Get("ip_pool_v4").(string))

--- a/appgate/resource_appgate_identity_provider_saml_test.go
+++ b/appgate/resource_appgate_identity_provider_saml_test.go
@@ -1213,3 +1213,188 @@ func testAccSamlIdentityProviderImportStateCheckFunc(expectedStates int) resourc
 		return nil
 	}
 }
+
+func TestAccSamlIdentityProvider61(t *testing.T) {
+	resourceName := "appgatesdp_saml_identity_provider.saml_test_resource"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSamlIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					testFor61AndAbove(t)
+				},
+				Config: testAccCheckSamlIdentityProvider61(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "admin_provider", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v6", "6935b379-205d-4fdd-847f-a0b5f14aff53"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "172.17.18.19"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "192.100.111.31"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.2", "192.100.111.32"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "internal.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.company.com/adfs/services/trust"),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"),
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "false"),
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "99"),
+					resource.TestCheckResourceAttr(resourceName, "network_inactivity_timeout_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccSamlIdentityProviderImportStateCheckFunc(1),
+			},
+			{
+				Config: testAccCheckSamlIdentityProvider61Updated(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSamlIdentityProviderExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "admin_provider", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v4", "f572b4ab-7963-4a90-9e5a-3bf033bfe2cc"),
+					resource.TestCheckResourceAttr(resourceName, "ip_pool_v6", "6935b379-205d-4fdd-847f-a0b5f14aff53"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.0", "172.17.18.19"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.1", "192.100.111.31"),
+					resource.TestCheckResourceAttr(resourceName, "dns_servers.2", "192.100.111.32"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dns_search_domains.0", "internal.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "redirect_url", "https://saml.company.com"),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "http://adfs-test.company.com/adfs/services/trust"),
+					resource.TestCheckResourceAttr(resourceName, "audience", "Company Appgate SDP"),
+					resource.TestCheckResourceAttrSet(resourceName, "provider_certificate"),
+					resource.TestCheckResourceAttr(resourceName, "decryption_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "block_local_dns_requests", "false"),
+					resource.TestCheckResourceAttr(resourceName, "inactivity_timeout_minutes", "5"),
+					resource.TestCheckResourceAttr(resourceName, "network_inactivity_timeout_enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "on_boarding_two_factor.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Saml"),
+					resource.TestCheckResourceAttr(resourceName, "claim_mappings.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccSamlIdentityProviderImportStateCheckFunc(1),
+			},
+		},
+	})
+}
+
+func testAccCheckSamlIdentityProvider61(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_ip_pool" "ip_v6_pool" {
+	ip_pool_name = "default pool v6"
+}
+
+data "appgatesdp_ip_pool" "ip_v4_pool" {
+	ip_pool_name = "default pool v4"
+}
+
+resource "appgatesdp_saml_identity_provider" "saml_test_resource" {
+	name = "%s"
+
+	admin_provider = true
+	ip_pool_v4     = data.appgatesdp_ip_pool.ip_v4_pool.id
+	ip_pool_v6     = data.appgatesdp_ip_pool.ip_v6_pool.id
+	dns_servers = [
+		"172.17.18.19",
+		"192.100.111.31",
+		"192.100.111.32",
+	]
+	dns_search_domains = [
+		"internal.company.com"
+	]
+	redirect_url = "https://saml.company.com"
+	issuer       = "http://adfs-test.company.com/adfs/services/trust"
+	audience     = "Company Appgate SDP"
+
+	provider_certificate = <<-EOF
+		-----BEGIN CERTIFICATE-----
+		MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+		BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+		GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+		MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+		HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+		BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+		+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+		ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+		AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+		gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+		DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+		jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+		eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+		-----END CERTIFICATE-----
+		EOF
+
+	inactivity_timeout_minutes         = 99
+	network_inactivity_timeout_enabled = true
+}`, rName)
+}
+
+func testAccCheckSamlIdentityProvider61Updated(rName string) string {
+	return fmt.Sprintf(`
+data "appgatesdp_ip_pool" "ip_v6_pool" {
+	ip_pool_name = "default pool v6"
+}
+
+data "appgatesdp_ip_pool" "ip_v4_pool" {
+	ip_pool_name = "default pool v4"
+}
+
+resource "appgatesdp_saml_identity_provider" "saml_test_resource" {
+	name = "%s"
+
+	admin_provider = true
+	ip_pool_v4     = data.appgatesdp_ip_pool.ip_v4_pool.id
+	ip_pool_v6     = data.appgatesdp_ip_pool.ip_v6_pool.id
+	dns_servers = [
+		"172.17.18.19",
+		"192.100.111.31",
+		"192.100.111.32",
+	]
+	dns_search_domains = [
+		"internal.company.com"
+	]
+	redirect_url = "https://saml.company.com"
+	issuer       = "http://adfs-test.company.com/adfs/services/trust"
+	audience     = "Company Appgate SDP"
+
+	provider_certificate = <<-EOF
+		-----BEGIN CERTIFICATE-----
+		MIICZjCCAc+gAwIBAgIUT0AsBLRI7aKjaMTnH1N9J6eS+7EwDQYJKoZIhvcNAQEL
+		BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+		GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA5MjIxNDQ5MTZaFw0yMTA5
+		MjIxNDQ5MTZaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+		HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwgZ8wDQYJKoZIhvcNAQEB
+		BQADgY0AMIGJAoGBAOWp5CnfLvNpjeESzTg/B/1kG1BRdXtM00q59WPj7adZ5gq+
+		+Hr0mWEQ5GldgmXRE3HsXfv7hiq4RwX9h+qtRinwhSvtLquM54/Fpw+TYZl5N27m
+		ov8a04qqlo8c3BqXR5Vp+ohPVcXs2I21k5bUTh5XwHj4uiv8uxmKzk42WETbAgMB
+		AAGjUzBRMB0GA1UdDgQWBBSpc1YN7rgPiBrVPn0roGV+1B4ETDAfBgNVHSMEGDAW
+		gBSpc1YN7rgPiBrVPn0roGV+1B4ETDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+		DQEBCwUAA4GBAMgxxBlfgH98ME7Es9xlV3HrurwG1p2gBvrrEACMtFNgtZE1vgck
+		jmhbc3t+Af9Dv9KBkaI6ZDl16uiptdpAv59wLgbVFgEPUJboRjhIaw5mPcMCeSDE
+		eIE/AV/qHWNEiLIMP5JO2FUbjpDCYtHkCOFDmv01e6rs86L3MQ8zF76T
+		-----END CERTIFICATE-----
+		EOF
+
+	inactivity_timeout_minutes         = 5
+	network_inactivity_timeout_enabled = false
+}`, rName)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/appgate/terraform-provider-appgatesdp
 go 1.13
 
 require (
-	github.com/appgate/sdp-api-client-go v1.0.7-0.20221213121146-2daabfd42a7f
+	github.com/appgate/sdp-api-client-go v1.0.7-0.20230220091716-993fd8f92b11
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221213121146-2daabfd42a7f h1:AZsC8zCxnBybQwun0sbqa/Ao3a2xhrPCM1laSj0Fm7I=
 github.com/appgate/sdp-api-client-go v1.0.7-0.20221213121146-2daabfd42a7f/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20230220091716-993fd8f92b11 h1:1e+KFjruKCvq1Y+bIQ6ZRaBRoGskZHuTrOzI8b6GQMA=
+github.com/appgate/sdp-api-client-go v1.0.7-0.20230220091716-993fd8f92b11/go.mod h1:aPyFeh0fein8VSxFPZpEkeMi8m9dbN+I1RVO4QrONyk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=

--- a/website/docs/r/connector_identity_provider.markdown
+++ b/website/docs/r/connector_identity_provider.markdown
@@ -44,11 +44,12 @@ The following arguments are supported:
 * `name`: (Required) Name of the object.
 * `notes`: (Optional) Notes for the object. Used for documentation purposes.
 * `tags`: (Optional) Array of tags.
-* `type`: (Required) The type of the Identity Provider.
+* `type`: (Computed) The type of the Identity Provider.
 * `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
 * `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
-* `on_boarding2_fa`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
 * `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.
@@ -85,7 +86,7 @@ The following arguments are supported:
 ### tags
 Array of tags.
 
-### on_boarding2_fa
+### on_boarding_two_factor
 On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 
 * `mfa_provider_id`: (Required) MFA provider ID to use for the authentication.

--- a/website/docs/r/ldap_certificate_identity_provider.markdown
+++ b/website/docs/r/ldap_certificate_identity_provider.markdown
@@ -90,7 +90,25 @@ EOF
 
 The following arguments are supported:
 
-
+* `ldap_identity_provider_id`: (Optional) ID of the object.
+* `name`: (Required) Name of the object.
+* `notes`: (Optional) Notes for the object. Used for documentation purposes.
+* `tags`: (Optional) Array of tags.
+* `type`: (Computed) The type of the Identity Provider.
+* `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
+* `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
+* `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
+* `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
+* `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.
+* `dns_search_domains`: (Optional) The DNS search domains to be assigned to Clients of the users in this Identity Provider.
+* `enforce_windows_network_profile_as_domain`: (Optional) If enabled, Windows Client will configure the network profile as "DomainAuthenticated".
+* `block_local_dns_requests`: (Optional) Whether the Windows Client will block local DNS requests or not.
+* `claim_mappings`: (Optional) The mapping of Identity Provider attributes to claims.
+* `on_demand_claim_mappings`: (Optional) The mapping of Identity Provider on demand attributes to claims.
+* `user_scripts`: (Optional) ID of the User Claim Scripts to run during authorization.
 * `hostnames`: (Required) Hostnames/IP addresses to connect.
 * `port`: (Required) Port to connect.
 * `ssl_enabled`: (Optional) Whether to use LDAPS protocol or not.
@@ -107,6 +125,42 @@ The following arguments are supported:
 * `certificate_attribute`: (Optional) The LDAP attribute to compare the Client certificate binary. Leave it null to skip this comparison.
 * `skip_x509_external_checks`: (Optional) By default, Controller contacts the endpoints on the certificate extensions in order to verify revocation status and pull the intermediate CA certificates. Set this flag in order to skip them.
 * `certificate_priorities`: (Optional) Client will order the available certificates according to the given priority list.
+
+
+
+### tags
+Array of tags.
+
+### on_boarding_two_factor
+On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+
+* `mfa_provider_id`: (Required) MFA provider ID to use for the authentication.
+* `message`:  (Optional) On-boarding MFA message to be displayed on the Client UI during the second-factor authentication. Example: Please use your multi factor authentication device to on-board..
+* `claim_suffix`:  (Optional)  default value `onBoarding` Upon successful on-boarding, the claim will be added as if MFA remedy action is fulfilled.
+* `always_required`:  (Optional) If enabled, MFA will be required on every authentication.
+* `device_limit_per_user`:  (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded. Deprecated. Use root level field instead.
+### dns_servers
+The DNS servers to be assigned to the Clients of the users in this Identity Provider.
+
+### dns_search_domains
+The DNS search domains to be assigned to Clients of the users in this Identity Provider.
+
+### claim_mappings
+The mapping of Identity Provider attributes to claims.
+
+* `attribute_name`: (Required) The name of the attribute coming from the Identity Provider.
+* `claim_name`: (Required) The name of the user claim to be used in Appgate SDP.
+* `list`:  (Optional)  default value `false` Whether the claim is expected to be a list and have multiple values or not.
+* `encrypt`:  (Optional)  default value `false` Whether the claim should be encrypt or not.
+### on_demand_claim_mappings
+The mapping of Identity Provider on demand attributes to claims.
+
+* `command`: (Required)  Enum values: `fileSize,fileExists,fileCreated,fileUpdated,fileVersion,fileSha512,processRunning,processList,serviceRunning,serviceList,regExists,regQuery,runScript`The name of the command.
+* `claim_name`: (Required) The name of the device claim to be used in Appgate SDP.
+* `parameters`:  (Optional) Depending on the command type, extra parameters to pass to the on-demand claim.
+* `platform`: (Required)  Enum values: `desktop.windows.all,desktop.macos.all,desktop.linux.all,desktop.all,mobile.android.all,mobile.ios.all,mobile.all,all`The platform(s) to run the on-demand claim.
+### user_scripts
+ID of the User Claim Scripts to run during authorization.
 
 
 ### hostnames

--- a/website/docs/r/ldap_identity_provider.markdown
+++ b/website/docs/r/ldap_identity_provider.markdown
@@ -119,11 +119,12 @@ The following arguments are supported:
 * `name`: (Required) Name of the object.
 * `notes`: (Optional) Notes for the object. Used for documentation purposes.
 * `tags`: (Optional) Array of tags.
-* `type`: (Required) The type of the Identity Provider.
+* `type`: (Computed) The type of the Identity Provider.
 * `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
 * `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
-* `on_boarding2_fa`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
 * `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.
@@ -149,7 +150,7 @@ The following arguments are supported:
 ### tags
 Array of tags.
 
-### on_boarding2_fa
+### on_boarding_two_factor
 On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 
 * `mfa_provider_id`: (Required) MFA provider ID to use for the authentication.

--- a/website/docs/r/local_database_identity_provider.markdown
+++ b/website/docs/r/local_database_identity_provider.markdown
@@ -55,11 +55,12 @@ The following arguments are supported:
 * `name`: (Required) Name of the object.
 * `notes`: (Optional) Notes for the object. Used for documentation purposes.
 * `tags`: (Optional) Array of tags.
-* `type`: (Required) The type of the Identity Provider.
+* `type`: (Computed) The type of the Identity Provider.
 * `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
 * `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
-* `on_boarding2_fa`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
 * `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.
@@ -96,7 +97,7 @@ The following arguments are supported:
 ### tags
 Array of tags.
 
-### on_boarding2_fa
+### on_boarding_two_factor
 On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 
 * `mfa_provider_id`: (Required) MFA provider ID to use for the authentication.

--- a/website/docs/r/radius_identity_provider.markdown
+++ b/website/docs/r/radius_identity_provider.markdown
@@ -117,11 +117,12 @@ The following arguments are supported:
 * `name`: (Required) Name of the object.
 * `notes`: (Optional) Notes for the object. Used for documentation purposes.
 * `tags`: (Optional) Array of tags.
-* `type`: (Required) The type of the Identity Provider.
+* `type`: (Computed) The type of the Identity Provider.
 * `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
 * `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
-* `on_boarding2_fa`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
 * `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.

--- a/website/docs/r/saml_identity_provider.markdown
+++ b/website/docs/r/saml_identity_provider.markdown
@@ -124,11 +124,12 @@ The following arguments are supported:
 * `name`: (Required) Name of the object.
 * `notes`: (Optional) Notes for the object. Used for documentation purposes.
 * `tags`: (Optional) Array of tags.
-* `type`: (Required) The type of the Identity Provider.
+* `type`: (Computed) The type of the Identity Provider.
 * `admin_provider`: (Optional) Whether the provider will be listed in the Admin UI or not.
 * `device_limit_per_user`: (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded.
-* `on_boarding2_fa`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
+* `on_boarding_two_factor`: (Optional) On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `inactivity_timeout_minutes`: (Optional) (Desktop) clients will sign out automatically after the user has been inactive on the device for the configured duration. Set it to 0 to disable.
+* `network_inactivity_timeout_enabled`: (Optional) Whether or not to take network inactivity into account when measuring client inactivity timeout.
 * `ip_pool_v4`: (Optional) The IPv4 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `ip_pool_v6`: (Optional) The IPv6 Pool ID the users in this Identity Provider are going to use to allocate IP addresses for the tunnels.
 * `dns_servers`: (Optional) The DNS servers to be assigned to the Clients of the users in this Identity Provider.
@@ -160,7 +161,7 @@ The following arguments are supported:
 ### tags
 Array of tags.
 
-### on_boarding2_fa
+### on_boarding_two_factor
 On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 
 * `mfa_provider_id`: (Required) MFA provider ID to use for the authentication.
@@ -168,6 +169,8 @@ On-boarding two-factor authentication settings. Leave it empty keep it disabled.
 * `claim_suffix`:  (Optional)  default value `onBoarding` Upon successful on-boarding, the claim will be added as if MFA remedy action is fulfilled.
 * `always_required`:  (Optional) If enabled, MFA will be required on every authentication.
 * `device_limit_per_user`:  (Optional) The device limit per user. The existing on-boarded devices will still be able to sign in even if the limit is exceeded. Deprecated. Use root level field instead.
+
+
 ### dns_servers
 The DNS servers to be assigned to the Clients of the users in this Identity Provider.
 


### PR DESCRIPTION
Updated identity provider resource to include missing attribute `network_inactivity_timeout_enabled` that was introduced in 6.1. This PR fixes #274 

Depends on:  https://github.com/appgate/sdp-api-client-go/pull/20

- updated the docs, some of the identity providers docs was out-of-date.