### PR TITLE
274/auto discover client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Version compatibility
 ---------------------------
 Our goal is to always support the latest stable release of Appgate.
 
-The current version of the master branch supports Appgate appliance API version 17.
+The current version of the master branch supports Appgate appliance API version 18.
 
 for more documentation about version compatibility, see the [terraform documentation](./website/docs/guides/version_compatibility.markdown).
 

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -283,7 +283,7 @@ func (c *Client) login(ctx context.Context) (*openapi.LoginResponse, error) {
 			if err, ok := err.(*openapi.GenericOpenAPIError); ok {
 				if responseErr, ok := err.Model().(openapi.LoginPost406Response); ok {
 					return &backoff.PermanentError{Err: &minMaxError{
-						Err: err,
+						Err: fmt.Errorf("Invalid appgatesdp.client_version for your collective %w", err),
 						Min: responseErr.GetMinSupportedVersion(),
 						Max: responseErr.GetMaxSupportedVersion(),
 					}}

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/appgate/sdp-api-client-go/api/v18/openapi"
-	pkgversion "github.com/appgate/terraform-provider-appgatesdp/version"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-version"
 )
@@ -39,6 +38,7 @@ type Config struct {
 	BearerToken  string `json:"appgate_bearer_token,omitempty"`
 	PemFilePath  string `json:"appgate_pem_filepath,omitempty"`
 	DeviceID     string `json:"appgate_device_id,omitempty"`
+	UserAgent    string
 }
 
 // Validate makes sure we have minimum required configuration values to authenticate against the controller.
@@ -112,9 +112,11 @@ func (c *Config) Client() (*Client, error) {
 		Timeout:   ((timeoutDuration * 2) * time.Second),
 	}
 	clientCfg := &openapi.Configuration{
-		DefaultHeader: map[string]string{},
-		UserAgent:     fmt.Sprintf("terraform-provider-appgatesdp/%s", pkgversion.ProviderVersion),
-		Debug:         c.Debug,
+		DefaultHeader: map[string]string{
+			"Accept": fmt.Sprintf("application/vnd.appgate.peer-v%d+json", MinimumSupportedVersion),
+		},
+		UserAgent: c.UserAgent,
+		Debug:     c.Debug,
 		Servers: []openapi.ServerConfiguration{
 			{
 				URL: c.URL,

--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -371,14 +371,6 @@ func TestClient(t *testing.T) {
 			if !appgateClient.ApplianceVersion.Equal(tt.expectedVersion) {
 				t.Fatalf("Expected %s, got %s", tt.expectedVersion, appgateClient.ApplianceVersion)
 			}
-
-			latestSupportedVersion, err := version.NewVersion(ApplianceVersionMap[DefaultClientVersion])
-			if err != nil {
-				t.Fatalf("unable to parse latest supported version")
-			}
-			if !appgateClient.LatestSupportedVersion.Equal(latestSupportedVersion) {
-				t.Fatalf("Expected Latest Version%s, got %s", tt.expectedVersion, appgateClient.ApplianceVersion)
-			}
 			if token != "Bearer very-long-string" {
 				t.Fatalf("Expected token Bearer very-long-string, got %s", appgateClient.Token)
 			}

--- a/appgate/config_test.go
+++ b/appgate/config_test.go
@@ -143,7 +143,6 @@ func TestLoginNotAcceptable(t *testing.T) {
 }
 
 var (
-	version52Test, _         = version.NewVersion("5.2.0+estimated")
 	computed54TestVersion, _ = version.NewVersion("5.4.0+estimated")
 
 	loginResponse54 = `
@@ -169,37 +168,6 @@ var (
 }
 `
 
-	loginResponsePrior53 = `
-{
-	"version": "4.3.0-20000",
-	"user": {
-		"name": "admin",
-		"needTwoFactorAuth": false,
-		"canAccessAuditLogs": true,
-		"privileges": [
-		{
-			"type": "All",
-			"target": "All",
-			"scope": {
-			"all": true,
-			"ids": [
-				"4c07bc67-57ea-42dd-b702-c2d6c45419fc"
-			],
-			"tags": [
-				"tag"
-			]
-			},
-			"defaultTags": [
-			"api-created"
-			]
-		}
-		]
-	},
-	"token": "very-long-string",
-	"expires": "2020-01-27T08:50:34Z",
-	"messageOfTheDay": "Welcome to Appgate SDP."
-}
-`
 	loginResponse406 = `
 {
 	"id": "string",
@@ -225,23 +193,6 @@ func TestClient(t *testing.T) {
 		config          *Config
 		wantInsecure    bool
 	}{
-		{
-			name: "test before 5.4",
-			fields: fields{
-				ResponseBody: loginResponsePrior53,
-			},
-			wantErr:         false,
-			expectedVersion: version52Test,
-			statusCode:      http.StatusOK,
-			config: &Config{
-				Username:     "admin",
-				Password:     "admin",
-				Version:      13,
-				LoginTimeout: 1,
-				Insecure:     true,
-			},
-			wantInsecure: true,
-		},
 		{
 			name: "test 5.4 login",
 			fields: fields{

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -26,7 +26,7 @@ const (
 	Version18 = 18
 	// DefaultClientVersion is the latest support version of appgate sdp client that is supported.
 	// its not recommended to change this value.
-	DefaultClientVersion = Version17
+	DefaultClientVersion = Version18
 )
 
 var (
@@ -87,7 +87,7 @@ func Provider() *schema.Provider {
 			"client_version": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CLIENT_VERSION", DefaultClientVersion),
+				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CLIENT_VERSION", 0),
 			},
 			"config_path": {
 				Type:        schema.TypeString,

--- a/appgate/provider.go
+++ b/appgate/provider.go
@@ -18,16 +18,17 @@ import (
 )
 
 const (
-	Version12 = 12
-	Version13 = 13
-	Version14 = 14
-	Version15 = 15
-	Version16 = 16
-	Version17 = 17
-	Version18 = 18
+	Version12 int = 12
+	Version13 int = 13
+	Version14 int = 14
+	Version15 int = 15
+	Version16 int = 16
+	Version17 int = 17
+	Version18 int = 18
 	// DefaultClientVersion is the latest support version of appgate sdp client that is supported.
 	// its not recommended to change this value.
-	DefaultClientVersion = Version18
+	DefaultClientVersion    = Version18
+	MinimumSupportedVersion = Version13
 )
 
 var (
@@ -86,9 +87,11 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("APPGATE_HTTP_DEBUG", false),
 			},
 			"client_version": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CLIENT_VERSION", 0),
+				Type:     schema.TypeInt,
+				Optional: true,
+				// lowest supported version available. This will be overwritten
+				// if the provisioner do not explcit overwrite it in their config
+				DefaultFunc: schema.EnvDefaultFunc("APPGATE_CLIENT_VERSION", MinimumSupportedVersion),
 			},
 			"config_path": {
 				Type:        schema.TypeString,

--- a/appgate/util.go
+++ b/appgate/util.go
@@ -234,15 +234,6 @@ func isUrl(str string) bool {
 	return err == nil && u.Scheme != "" && u.Host != ""
 }
 
-func contains(s []int, e int) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 // getResourceFileContent gets content from key "file" filepath schema.ResourceData or string payload "content".
 func getResourceFileContent(d *schema.ResourceData, key string) ([]byte, error) {
 	var content []byte

--- a/website/docs/guides/version_compatibility.markdown
+++ b/website/docs/guides/version_compatibility.markdown
@@ -14,12 +14,18 @@ You need to specify the `client_version` if you are not running the latest suppo
 The `client_version` tries to maintain backwards compatibility 2 versions back all the time.
 
 
-|                         	|  client version 14 	| client version 15 	    | client version 16   | **client version 17**     |
-|-------------------------	|--------------------	|-------------------	    |-------------------	|-------------------   |
-| Appgate SDP 5.3.*     	| Full support  	|    |      	  |      |
-| Appgate SDP 5.4.*     	| Partial support   	| Full support  	      |    |  |
-| *Appgate SDP 5.5.*   	  | Partial support   	| Partial support   	    | Full support    |    |
-| **Appgate SDP 6.0.***   | Partial support   	| Partial support   	    | Partial support     | **Full support**     |
+~> **NOTE:**  The `client_version` can be omitted from the provider `"appgatesdp" { }` configuration block. If its not set by either environment variable or configuration block, the provider will use the highest available version that the controller allows by default.
+
+
+
+
+|                         	|  client version 14 	| client version 15 	    | client version 16   | client version 17     |**client version 18**     |
+|-------------------------	|--------------------	|-------------------	    |-------------------	|-------------------   |-------------------   |
+| Appgate SDP 5.3.*     	| Full support  	|    |      	  |      |      |
+| Appgate SDP 5.4.*     	| Partial support   	| Full support  	      |    |  | | |
+| *Appgate SDP 5.5.*   	  | Partial support   	| Partial support   	    | Full support    |    | |
+| **Appgate SDP 6.0.***   | Partial support   	| Partial support   	    | Partial support     | **Full support**     | |
+| **Appgate SDP 6.1.***   | Partial support   	| Partial support   	    | Partial support     |   Full support  | **Full support**|
 
 
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -90,7 +90,7 @@ the following keys are allowed within the config file, all keys are optional.
     "appgate_password": "string",
     "appgate_provider": "string",
     "appgate_bearer_token": "string",
-    "appgate_client_version": 17,
+    "appgate_client_version": 18,
 }
 
 ```
@@ -102,7 +102,7 @@ example config file format,
     "appgate_username": "admin",
     "appgate_password": "admin",
     "appgate_provider": "local",
-    "appgate_client_version": 17
+    "appgate_client_version": 18
 }
 
 ```
@@ -156,7 +156,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `provider` - (Optional) This is the Appgate provider. It must be provided, but
   it can also be sourced from the `APPGATE_PROVIDER` environment variables.
 
-* `client_version` - (Optional) This reference the appgate client SDK version, it can also be sourced from the `APPGATE_CLIENT_VERSION` environment variables. Defaults to `17`, Its not recommended to change this unless you know what you are doing.
+* `client_version` - (Optional) This reference the appgate client SDK version, it can also be sourced from the `APPGATE_CLIENT_VERSION` environment variables. Defaults to `18`, Its not recommended to change this unless you know what you are doing.
 
 * `pem_filepath` - (Optional) Path to the controller's CA cert file in PEM format.
 


### PR DESCRIPTION
- automatically compute client_version if ommited from config based on max allowed version the controller support
- (based on conversation in https://github.com/appgate/terraform-provider-appgatesdp/issues/274#issuecomment-1448831020)
- Updated User-Agent to include provider version
