### PR TITLE
removed appliance.hostname deprecation notice

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -53,8 +53,7 @@ func resourceAppgateAppliance() *schema.Resource {
 
 			"hostname": {
 				Type:        schema.TypeString,
-				Deprecated:  "appliance hostname is deprecated as of 5.4.",
-				Description: "Name of the object.",
+				Description: "Hostname of the Appliance. It's used by other Appliances to communicate with and identify this Appliances.",
 				Required:    true,
 			},
 


### PR DESCRIPTION
`appliance.hostname` is here to stay. There was plans before to remove it, but we still need it for the foreseeable future.