### PR TITLE
client profile url attribute

### DIFF
--- a/appgate/resource_appgate_client_profile.go
+++ b/appgate/resource_appgate_client_profile.go
@@ -253,6 +253,13 @@ func resourceAppgateClientProfileRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("hostname", profile.GetHostname())
 	d.Set("exported", profile.GetExported().String())
 
+	url, _, err := api.ClientProfilesIdUrlGet(ctx, profile.GetId()).Authorization(token).Execute()
+	if err != nil {
+		diags = AppendFromErr(diags, err)
+		return diags
+	}
+	d.Set("url", url.GetUrl())
+
 	return nil
 }
 

--- a/appgate/resource_appgate_client_profile_test.go
+++ b/appgate/resource_appgate_client_profile_test.go
@@ -3,6 +3,7 @@ package appgate
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -133,6 +134,9 @@ func TestAccClientProfileBasic61(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "acme"),
 					resource.TestCheckResourceAttr(resourceName, "spa_key_name", "development-acme"),
 					resource.TestCheckResourceAttr(resourceName, "identity_provider_name", "local"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					// https://github.com/appgate/terraform-provider-appgatesdp/issues/288
+					resource.TestMatchResourceAttr(resourceName, "url", regexp.MustCompile(`(appgate\:\/\/acme.com/)(\w+)`)),
 				),
 			},
 			{


### PR DESCRIPTION
the `url` attribute was removed in the default endpoint  `/admin/client-profiles/{ID}` in 6.1 and moved to a separate endpoint `admin/client-profiles/{ID}/url`

This PR make sure we still get the url attribute on `appgatesdp_client_profile` resource.

This PR fixes #288