### PR TITLE
Set only netmask if address is set.

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -2829,10 +2829,12 @@ func readGatewayFromConfig(gateways []interface{}) (openapi.ApplianceAllOfGatewa
 						ad := openapi.ApplianceAllOfGatewayVpnAllowDestinations{}
 						if v := raw["address"].(string); v != "" {
 							ad.SetAddress(v)
+							// we can only set netmask if a address is set.
+							if v, ok := raw["netmask"].(int); ok && v >= 0 {
+								ad.SetNetmask(int32(v))
+							}
 						}
-						if v, ok := raw["netmask"].(int); ok && v >= 0 {
-							ad.SetNetmask(int32(v))
-						}
+
 						if v := raw["nic"].(string); v != "" {
 							ad.SetNic(v)
 						}

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -521,7 +521,7 @@ func TestAccApplianceBasicController(t *testing.T) {
 }
 
 //lint:file-ignore U1000 Debug function, used during development
-func testAccCheckExampleWidgetExists(resourceName string) resource.TestCheckFunc {
+func testAccCheckDumpResource(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// retrieve the resource by name from state
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -35,6 +35,9 @@ var applianceConstraintCheck = func(t *testing.T, constraint string) {
 var applianceTestForFiveFive = func(t *testing.T) {
 	applianceConstraintCheck(t, ">= 5.5, < 6.0")
 }
+var applianceTestForFiveFiveOrHigher = func(t *testing.T) {
+	applianceConstraintCheck(t, ">= 5.5")
+}
 
 var testFor6AndAbove = func(t *testing.T) {
 	applianceConstraintCheck(t, ">= 6.0")
@@ -64,6 +67,7 @@ func TestAccApplianceBasicController(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
+					// this test include peer_interface which is not allowed on higher versions
 					applianceTestForFiveFive(t)
 				},
 				Config: testAccCheckApplianceBasicController(context),
@@ -1324,6 +1328,7 @@ func TestAccApplianceBasicGateway(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				PreConfig: func() {
+					// this test include peer_interface which is not allowed on higher versions
 					applianceTestForFiveFive(t)
 				},
 				Config: testAccCheckApplianceBasicGateway(context),
@@ -4411,6 +4416,526 @@ resource "appgatesdp_appliance" "log_forwarder_tcp" {
 		sites = [
 			data.appgatesdp_site.default_site.id
 		]
+	}
+}
+
+`, context)
+}
+
+func TestAccApplianceBasicGateway6(t *testing.T) {
+	resourceName := "appgatesdp_appliance.gateway"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":     rName,
+		"hostname": fmt.Sprintf("%s.devops", rName),
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApplianceDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					// this test include peer_interface which is not allowed on higher versions
+					applianceTestForFiveFiveOrHigher(t)
+				},
+				Config: testAccApplianceGatewayVPN(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connect_to_peers_using_client_port_with_spa", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.advanced_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.express_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "customization", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.port", "5555"),
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "hostname_aliases.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "hostname_aliases.0", "y.com"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.aws_kineses.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sites.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.splunk.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sumo_logic.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.tcp_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.mtu", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Second gateway, defined in terraform."),
+					resource.TestCheckResourceAttr(resourceName, "ntp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.hostname", "0.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.hostname", "1.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.hostname", "2.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.hostname", "3.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ping.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.external_profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.https_p12.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.proxy_p12s.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.auto_redirect", "false"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_color", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_image", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_image_checksum", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.logo", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.logo_checksum", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.text", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.text_color", ""),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.port", "5556"),
+					resource.TestCheckResourceAttr(resourceName, "rsyslog_destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.snmpd_conf", ""),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.tcp_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.udp_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.password_authentication", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.port", "22"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateCheck:        testAccApplianceImportStateCheckFunc(1),
+				ImportStateVerifyIgnore: []string{"site", "seed_file"},
+			},
+			{
+				Config: testAccApplianceGatewayVPNUpdated(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connect_to_peers_using_client_port_with_spa", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.advanced_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "connector.0.express_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "controller.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "controller.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "customization", ""),
+					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", "192.168.111.0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "24"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "healthcheck_server.0.port", "5555"),
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "hostname_aliases.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "hostname_aliases.0", "y.com"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.aws_kineses.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.elasticsearch.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sites.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.splunk.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.sumo_logic.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_forwarder.0.tcp_clients.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "log_server.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.mtu", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "notes", "hello world"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.hostname", "0.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.0.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.hostname", "1.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.1.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.hostname", "2.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.2.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.hostname", "3.ubuntu.pool.ntp.org"),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key", ""),
+					resource.TestCheckResourceAttr(resourceName, "ntp.0.servers.3.key_type", ""),
+					resource.TestCheckResourceAttr(resourceName, "peer_interface.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ping.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ping.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.%", "6"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.external_profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.https_p12.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.profiles.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.proxy_p12s.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.%", "8"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.auto_redirect", "false"),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_color", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_image", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.background_image_checksum", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.logo", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.logo_checksum", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.text", ""),
+					resource.TestCheckResourceAttr(resourceName, "portal.0.sign_in_customization.0.text_color", ""),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.port", "5556"),
+					resource.TestCheckResourceAttr(resourceName, "rsyslog_destinations.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.allow_sources.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.snmpd_conf", ""),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.tcp_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "snmp_server.0.udp_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.0.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.allow_sources.1.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.password_authentication", "true"),
+					resource.TestCheckResourceAttr(resourceName, "ssh_server.0.port", "22"),
+					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.0", "test"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateCheck:        testAccApplianceImportStateCheckFunc(1),
+				ImportStateVerifyIgnore: []string{"site", "seed_file"},
+			},
+		},
+	})
+}
+
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/304
+func testAccApplianceGatewayVPN(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+resource "appgatesdp_appliance" "gateway" {
+	name             = "%{name}"
+	hostname         = "%{hostname}"
+	hostname_aliases = ["y.com"]
+
+	tags = ["test"]
+	client_interface {
+		hostname = "%{hostname}"
+
+		allow_sources {
+		address = "0.0.0.0"
+		netmask = 0
+		}
+		allow_sources {
+		address = "::"
+		netmask = 0
+		}
+	}
+	ntp {
+		servers {
+		hostname = "0.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "1.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "2.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "3.ubuntu.pool.ntp.org"
+		}
+	}
+
+	notes = "Second gateway, defined in terraform."
+	site  = data.appgatesdp_site.default_site.id
+	networking {
+		nics {
+		enabled = true
+		name    = "eth0"
+		ipv4 {
+			dhcp {
+			enabled = true
+			dns     = true
+			routers = true
+			ntp     = true
+			}
+		}
+		}
+	}
+	ssh_server {
+		enabled                 = true
+		port                    = 22
+		password_authentication = true
+		allow_sources {
+		address = "0.0.0.0"
+		netmask = 0
+		}
+		allow_sources {
+		address = "::"
+		netmask = 0
+		}
+	}
+	gateway {
+		enabled = true
+		vpn {
+		weight = 100
+		allow_destinations {
+				nic = "eth0"
+			}
+		}
+	}
+}
+
+`, context)
+}
+
+// https://github.com/appgate/terraform-provider-appgatesdp/issues/304
+func testAccApplianceGatewayVPNUpdated(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+resource "appgatesdp_appliance" "gateway" {
+	name             = "%{name}"
+	hostname         = "%{hostname}"
+	hostname_aliases = ["y.com"]
+
+	tags = ["test"]
+	client_interface {
+		hostname = "%{hostname}"
+
+		allow_sources {
+		address = "0.0.0.0"
+		netmask = 0
+		}
+		allow_sources {
+		address = "::"
+		netmask = 0
+		}
+	}
+	ntp {
+		servers {
+		hostname = "0.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "1.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "2.ubuntu.pool.ntp.org"
+		}
+		servers {
+		hostname = "3.ubuntu.pool.ntp.org"
+		}
+	}
+
+	notes = "hello world"
+	site  = data.appgatesdp_site.default_site.id
+	networking {
+		nics {
+		enabled = true
+		name    = "eth0"
+		ipv4 {
+			dhcp {
+			enabled = true
+			dns     = true
+			routers = true
+			ntp     = true
+			}
+		}
+		}
+	}
+	ssh_server {
+		enabled                 = true
+		port                    = 22
+		password_authentication = true
+		allow_sources {
+		address = "0.0.0.0"
+		netmask = 0
+		}
+		allow_sources {
+		address = "::"
+		netmask = 0
+		}
+	}
+	gateway {
+		enabled = true
+		vpn {
+		weight = 100
+		allow_destinations {
+				nic = "eth0"
+				address = "192.168.111.0"
+				netmask = 24
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
resolve appliance.gateway.vpn.allow_destinations address/netmask set

set only netmask if a address is set.
This commit fixes https://github.com/appgate/terraform-provider-appgatesdp/issues/304