### PR TITLE
[ZTP-1775] Double login validation timeout for controller to 10 minutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ terraform.tfstate*
 /dist/
 state-migrate
 appgate/test-fixtures/appliance_customization_file_test.zip
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=1.4.0
+VERSION=1.4.1
 
 commit=$$(git rev-parse HEAD)
 

--- a/appgate/config.go
+++ b/appgate/config.go
@@ -261,7 +261,7 @@ func (c *Client) loginTimoutDuration() time.Duration {
 	if c.Config.LoginTimeout > 0 {
 		return time.Duration(c.Config.LoginTimeout) * time.Second
 	}
-	return 5 * time.Minute
+	return 10 * time.Minute
 }
 
 type minMaxError struct {


### PR DESCRIPTION
@danijeel Looks like `Config.LoginTimeoutDuration` is already configurable but the code comments says 
```golang
	// This is just intend to be used within unit tests.
	if c.Config.LoginTimeout > 0 {
		return time.Duration(c.Config.LoginTimeout) * time.Second
	}
```