### PR TITLE
basic_auth, allowed_users, use_https, and https_p12  for appliance.prometheusExporter are only available since 6.2

### DIFF
--- a/appgate/resource_appgate_appliance.go
+++ b/appgate/resource_appgate_appliance.go
@@ -3238,26 +3238,26 @@ func readPrometheusExporterFromConfig(exporters []interface{}, currentVersion *v
 			}
 			val.SetAllowSources(allowSources)
 		}
-		if v, ok := rawServer["https_p12"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			p12, err := readP12(v[0])
-			if err != nil {
-				return val, err
-			}
-			val.SetHttpsP12(p12)
-		}
-		if v, ok := rawServer["allowed_users"].([]interface{}); ok && len(v) > 0 {
-			allowedUsers, err := readAllowedUsers(v)
-			if err != nil {
-				return val, err
-			}
-			val.SetAllowedUsers(allowedUsers)
-		}
-		if currentVersion.GreaterThanOrEqual(Appliance60Version) {
+		if currentVersion.GreaterThanOrEqual(Appliance62Version) {
 			if v, ok := rawServer["basic_auth"]; ok {
 				val.SetBasicAuth(v.(bool))
 			}
 			if v, ok := rawServer["use_https"]; ok {
 				val.SetUseHTTPS(v.(bool))
+			}
+			if v, ok := rawServer["https_p12"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				p12, err := readP12(v[0])
+				if err != nil {
+					return val, err
+				}
+				val.SetHttpsP12(p12)
+			}
+			if v, ok := rawServer["allowed_users"].([]interface{}); ok && len(v) > 0 {
+				allowedUsers, err := readAllowedUsers(v)
+				if err != nil {
+					return val, err
+				}
+				val.SetAllowedUsers(allowedUsers)
 			}
 		}
 	}

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -5125,6 +5125,173 @@ resource "appgatesdp_appliance" "appliancev62_metrics_aggregator" {
 `, context)
 }
 
+
+func TestAccAppliance61(t *testing.T) {
+	resourceName := "appgatesdp_appliance.appliancev61"
+	rName := RandStringFromCharSet(10, CharSetAlphaNum)
+	context := map[string]interface{}{
+		"name":     rName,
+		"hostname": fmt.Sprintf("%s.devops", rName),
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApplianceDestroy,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					testFor61AndAbove(t)
+				},
+				Config: testAccAppliance61(context),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplianceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "notes", "Managed by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "hostname", context["hostname"].(string)),
+
+					resource.TestCheckResourceAttr(resourceName, "client_interface.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.0.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.address", "::"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.allow_sources.1.nic", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.dtls_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.hostname", context["hostname"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.https_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.override_spa_mode", "Disabled"),
+					resource.TestCheckResourceAttr(resourceName, "client_interface.0.proxy_protocol", "false"),
+
+					resource.TestCheckResourceAttr(resourceName, "networking.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.hosts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.%", "5"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.ntp", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.dhcp.0.routers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv4.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.dhcp.0.ntp", "false"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.static.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.ipv6.0.virtual_ip", ""),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.mtu", "0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.nics.0.name", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "networking.0.routes.#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.%", "7"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.address", "127.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.netmask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.allow_sources.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "prometheus_exporter.0.port", "1234"),
+
+					resource.TestCheckResourceAttr(resourceName, "gateway.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.address", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.netmask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.allow_destinations.0.nic", "eth0"),
+					resource.TestCheckResourceAttr(resourceName, "gateway.0.vpn.0.weight", "100"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  testAccApplianceImportStateCheckFunc(1),
+				ImportStateVerifyIgnore: []string{"site", "seed_file",
+					// we can't import verify local file path
+					"prometheus_exporter.0.https_p12.0.content",
+					"prometheus_exporter.0.allowed_users.0.password",
+					"prometheus_exporter.0.allowed_users.1.password",
+					"log_forwarder.0.azure_monitor.0.app_secret",
+					"log_forwarder.0.falcon_log_scale.0.token",
+				},
+			},
+		},
+	})
+}
+
+func testAccAppliance61(context map[string]interface{}) string {
+	return Nprintf(`
+data "appgatesdp_site" "default_site" {
+	site_name = "Default Site"
+}
+resource "appgatesdp_appliance" "appliancev61" {
+	name             = "%{name}"
+	hostname         = "%{hostname}"
+	site  = data.appgatesdp_site.default_site.id
+	client_interface {
+		hostname = "%{hostname}"
+
+		allow_sources {
+		address = "0.0.0.0"
+		netmask = 0
+		}
+		allow_sources {
+		address = "::"
+		netmask = 0
+		}
+	}
+	networking {
+		nics {
+			enabled = true
+			name    = "eth0"
+			ipv4 {
+				dhcp {
+					enabled = true
+					dns     = true
+					routers = true
+					ntp     = true
+				}
+			}
+		}
+	}
+	prometheus_exporter {
+		enabled = true
+		port    = 1234
+		allow_sources {
+			address = "127.0.0.1"
+			netmask = 32
+			nic     = "eth0"
+		}
+	}
+	gateway {
+		enabled = true
+		vpn {
+			weight = 100
+			allow_destinations {
+				nic     = "eth0"
+				address = "0.0.0.0"
+				netmask = 0
+			}
+		}
+	}
+}
+
+`, context)
+}
+
 func TestAccAppliance62(t *testing.T) {
 	resourceName := "appgatesdp_appliance.appliancev62"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)

--- a/appgate/resource_appgate_appliance_test.go
+++ b/appgate/resource_appgate_appliance_test.go
@@ -5125,7 +5125,6 @@ resource "appgatesdp_appliance" "appliancev62_metrics_aggregator" {
 `, context)
 }
 
-
 func TestAccAppliance61(t *testing.T) {
 	resourceName := "appgatesdp_appliance.appliancev61"
 	rName := RandStringFromCharSet(10, CharSetAlphaNum)


### PR DESCRIPTION
Some fields for `appliance.prometheus_exporter` had the wrong version checking code