### PR TITLE
Revert "site.name_resolution.dns_forwarding requires at least site_ipv4 or site_ipv6"

### DIFF
--- a/appgate/resource_appgate_site.go
+++ b/appgate/resource_appgate_site.go
@@ -1221,9 +1221,6 @@ func readSiteNameResolutionFromConfig(currentVersion *version.Version, nameresol
 				}
 				result.SetDnsForwarding(dnsForwardingResolvers)
 			}
-			if dnsForwardingResolvers.SiteIpv4 == nil && dnsForwardingResolvers.SiteIpv6 == nil {
-				return result, errors.New("either site_ipv4 or site_ipv6 must be set")
-			}
 		}
 		if currentVersion.GreaterThanOrEqual(Appliance61Version) {
 			if v, ok := raw["illumio_resolvers"]; ok {


### PR DESCRIPTION
This reverts commit b9e43a280b2a1e7c4121a1475c6204103978ff3d.