### PR TITLE
Wrong data type used for `appgatesdp_oidc_identity_provider.claim_mappings`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOARCH=$(shell go env GOARCH)
 HOSTNAME=appgate.com
 NAMESPACE=appgate
 NAME=appgatesdp
-VERSION=1.4.1
+VERSION=9.9.9
 
 commit=$$(git rev-parse HEAD)
 

--- a/appgate/resource_appgate_blacklist_user_test.go
+++ b/appgate/resource_appgate_blacklist_user_test.go
@@ -18,9 +18,9 @@ func TestAccBlacklistUserBasic(t *testing.T) {
 			{
 				Config: testAccCheckBlacklistUserBasic(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "id", "CN=TestUser,OU=ldap"),
-					resource.TestCheckResourceAttr(resourceName, "provider_name", "ldap"),
-					resource.TestCheckResourceAttr(resourceName, "user_distinguished_name", "CN=TestUser,OU=ldap"),
+					resource.TestCheckResourceAttr(resourceName, "id", "CN=TestUser,OU=local"),
+					resource.TestCheckResourceAttr(resourceName, "provider_name", "local"),
+					resource.TestCheckResourceAttr(resourceName, "user_distinguished_name", "CN=TestUser,OU=local"),
 					resource.TestCheckResourceAttr(resourceName, "username", "TestUser"),
 				),
 			},
@@ -36,7 +36,7 @@ func TestAccBlacklistUserBasic(t *testing.T) {
 func testAccCheckBlacklistUserBasic() string {
 	return `
     resource "appgatesdp_blacklist_user" "test_blacklist_user" {
-        user_distinguished_name = "CN=TestUser,OU=ldap"
+        user_distinguished_name = "CN=TestUser,OU=local"
       }
 `
 }

--- a/appgate/resource_appgate_identity_provider_connector.go
+++ b/appgate/resource_appgate_identity_provider_connector.go
@@ -157,7 +157,7 @@ func resourceAppgateConnectorProviderRuleUpdate(d *schema.ResourceData, meta int
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalConnectorProvider.SetClaimMappings(claims)
 	}
 	// TODO is this needed?

--- a/appgate/resource_appgate_identity_provider_ldap.go
+++ b/appgate/resource_appgate_identity_provider_ldap.go
@@ -343,12 +343,12 @@ func resourceAppgateLdapProviderRuleUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLdapProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLdapProvider.SetOnDemandClaimMappings(claims)
 	}
 

--- a/appgate/resource_appgate_identity_provider_ldap_certificate.go
+++ b/appgate/resource_appgate_identity_provider_ldap_certificate.go
@@ -368,12 +368,12 @@ func resourceAppgateLdapCertificateProviderRuleUpdate(d *schema.ResourceData, me
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLdapCertificateProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLdapCertificateProvider.SetOnDemandClaimMappings(claims)
 	}
 

--- a/appgate/resource_appgate_identity_provider_local_database.go
+++ b/appgate/resource_appgate_identity_provider_local_database.go
@@ -223,12 +223,12 @@ func resourceAppgateLocalDatabaseProviderRuleUpdate(d *schema.ResourceData, meta
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLocalDatabaseProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalLocalDatabaseProvider.SetOnDemandClaimMappings(claims)
 	}
 

--- a/appgate/resource_appgate_identity_provider_oidc.go
+++ b/appgate/resource_appgate_identity_provider_oidc.go
@@ -268,7 +268,7 @@ func resourceAppgateOidcProviderRuleRead(d *schema.ResourceData, meta interface{
 }
 
 func resourceAppgateOidcProviderRuleUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG] Updating radius identity provider id: %+v", d.Id())
+	log.Printf("[DEBUG] Updating oidc identity provider id: %+v", d.Id())
 	token, err := meta.(*Client).GetToken()
 	if err != nil {
 		return err

--- a/appgate/resource_appgate_identity_provider_oidc.go
+++ b/appgate/resource_appgate_identity_provider_oidc.go
@@ -350,12 +350,12 @@ func resourceAppgateOidcProviderRuleUpdate(d *schema.ResourceData, meta interfac
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalOidcProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalOidcProvider.SetOnDemandClaimMappings(claims)
 	}
 

--- a/appgate/resource_appgate_identity_provider_radius.go
+++ b/appgate/resource_appgate_identity_provider_radius.go
@@ -317,12 +317,12 @@ func resourceAppgateRadiusProviderRuleUpdate(d *schema.ResourceData, meta interf
 	}
 	if d.HasChange("claim_mappings") {
 		_, v := d.GetChange("claim_mappings")
-		claims := readIdentityProviderClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderClaimMappingFromConfig(v.(*schema.Set).List())
 		originalRadiusProvider.SetClaimMappings(claims)
 	}
 	if d.HasChange("on_demand_claim_mappings") {
 		_, v := d.GetChange("on_demand_claim_mappings")
-		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.([]interface{}))
+		claims := readIdentityProviderOnDemandClaimMappingFromConfig(v.(*schema.Set).List())
 		originalRadiusProvider.SetOnDemandClaimMappings(claims)
 	}
 


### PR DESCRIPTION
Fix for #375 

When fetching the config, we should be converting the data into `schema.Set`, not `[]interface{}`

```
appgatesdp_oidc_identity_provider.oidc: Modifying... [id=bbb86809-4c41-43f3-a1cb-1927825b478f]
╷
│ Error: Plugin did not respond
│
│   with appgatesdp_oidc_identity_provider.oidc,
│   on main.tf line 46, in resource "appgatesdp_oidc_identity_provider" "oidc":
│   46: resource "appgatesdp_oidc_identity_provider" "oidc" {
│
│ The plugin encountered an error, and failed to respond to the plugin.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-appgatesdp_v9.9.9 plugin:

panic: interface conversion: interface {} is *schema.Set, not []interface {}

goroutine 23 [running]:
github.com/appgate/terraform-provider-appgatesdp/appgate.resourceAppgateOidcProviderRuleUpdate(0x1400011cb00, {0x1056b1420, 0x140001f1b80})
	/Users/mando/Git/terraform-provider-appgatesdp/appgate/resource_appgate_identity_provider_oidc.go:352 +0x19d8
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0x105807128?, {0x105807128?, 0x1400054fcb0?}, 0xd?, {0x1056b1420?, 0x140001f1b80?})
	/Users/mando/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:828 +0x130
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x14000447dc0, {0x105807128, 0x1400054fcb0}, 0x14000155860, 0x1400011c980, {0x1056b1420, 0x140001f1b80})
	/Users/mando/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:947 +0x660
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x140003706f0, {0x105807128?, 0x1400054fbf0?}, 0x1400055e500)
	/Users/mando/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:1153 +0xaa4
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140002dc460, {0x105807128?, 0x1400054f230?}, 0x14000161570)
	/Users/mando/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/tf5server/server.go:865 +0x2a8
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x1057b44a0, 0x140002dc460}, {0x105807128, 0x1400054f230}, 0x1400011d580, 0x0)
	/Users/mando/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:518 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x140001a7000, {0x105807128, 0x1400054f1a0}, {0x10580bf40, 0x14000590000}, 0x1400055ad80, 0x1400046d4a0, 0x105fd2af8, 0x0)
	/Users/mando/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x140001a7000, {0x10580bf40, 0x14000590000}, 0x1400055ad80)
	/Users/mando/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/Users/mando/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1019 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 20
	/Users/mando/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c

Error: The terraform-provider-appgatesdp_v9.9.9 plugin crashed!
```